### PR TITLE
GH-2: Add optional SPZ export alongside PLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The first run downloads the SHARP checkpoint (~2.6 GB) into `~/.cache/torch/hu
 
 1. Drop an image (or browse). HEIC is supported if `pillow-heif` is installed (comes with ml-sharp).
 2. **Generate** — wait for inference (MPS/CUDA/CPU depending on your machine).
-3. Orbit with the mouse; **arrow keys** move along the view (↑/→ forward, ↓/← back); **Splat size** slider adjusts screen-space scale; **Previous scenes** reloads saved `.ply` files from `outputs/`.
+3. Orbit with the mouse; **arrow keys** move along the view (↑/→ forward, ↓/← back); **Splat size** slider adjusts screen-space scale; **Previous scenes** reloads saved scenes from `outputs/` (each run writes `splat.ply` for the web viewer and, when conversion succeeds, a compressed `splat.spz` for tools that use the [SPZ](https://github.com/nianticlabs/spz) format).
 
 ## References
 
@@ -83,5 +83,6 @@ The first run downloads the SHARP checkpoint (~2.6 GB) into `~/.cache/torch/hu
 - **3D Gaussian splat preview (browser):** [GaussianSplats3D](https://github.com/mkkellogg/GaussianSplats3D) by Mark Kellogg, consumed as [`@mkkellogg/gaussian-splats-3d@0.4.6`](https://unpkg.com/@mkkellogg/gaussian-splats-3d@0.4.6/) from the [unpkg](https://unpkg.com/) CDN (imported in `static/main.js`). npm listing: [`@mkkellogg/gaussian-splats-3d`](https://www.npmjs.com/package/@mkkellogg/gaussian-splats-3d). See the upstream [license](https://github.com/mkkellogg/GaussianSplats3D/blob/main/LICENSE).
 - **WebGL / math (browser):** [Three.js](https://threejs.org/) **r170** (npm `three@0.170.0`) as an ES module, loaded via an import map from unpkg in `static/index.html` (unpkg URLs use that semver, not `three@r170`).
 - **Monocular splats (local inference):** [Apple ml-sharp](https://github.com/apple/ml-sharp) and its model weights; use is subject to their [LICENSE](https://github.com/apple/ml-sharp/blob/main/LICENSE) and [LICENSE_MODEL](https://github.com/apple/ml-sharp/blob/main/LICENSE_MODEL).
+- **SPZ export (optional sibling file):** [GaussForge](https://github.com/3dgscloud/GaussForge) converts vertex-only PLY to [Niantic SPZ](https://github.com/nianticlabs/spz) (`pip` package `gaussforge`); the in-browser viewer still uses `.ply`.
 
 Third-party scripts are fetched from **unpkg** at runtime in development-style setups; for stricter deployments, vendor these files or use your own CDN and integrity checks.

--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ Or manually:
 
 from __future__ import annotations
 
+import io
 import json
 import logging
 import threading
@@ -114,6 +115,32 @@ def _scene_id_ok(scene_id: str) -> bool:
         return False
 
 
+def _export_sharp_ply_to_spz(ply_path: Path, spz_path: Path) -> bool:
+    """Write Niantic-style .spz from SHARP splat.ply (vertex-only PLY for GaussForge)."""
+    try:
+        import gaussforge
+        from plyfile import PlyData, PlyElement
+    except ImportError:
+        LOGGER.warning("gaussforge or plyfile missing; install requirements.txt for .spz export")
+        return False
+    try:
+        plydata = PlyData.read(str(ply_path))
+        vertex_el = plydata["vertex"]
+        minimal = PlyData([PlyElement.describe(vertex_el.data, "vertex")])
+        buf = io.BytesIO()
+        minimal.write(buf)
+        result = gaussforge.GaussForge().convert(buf.getvalue(), "ply", "spz")
+        if "error" in result:
+            LOGGER.warning("SPZ conversion failed: %s", result.get("error"))
+            return False
+        raw = result["data"]
+        spz_path.write_bytes(raw if isinstance(raw, (bytes, bytearray)) else bytes(raw))
+        return True
+    except Exception:
+        LOGGER.exception("SPZ export failed for %s", ply_path)
+        return False
+
+
 @app.route("/favicon.ico")
 def favicon() -> Any:
     """Avoid 404 spam when the browser requests a default favicon."""
@@ -160,14 +187,15 @@ def list_scenes() -> Any:
                     label = original_name
             except (json.JSONDecodeError, OSError):
                 pass
-        scenes.append(
-            {
-                "id": d.name,
-                "label": label,
-                "original_name": original_name,
-                "mtime": ply.stat().st_mtime,
-            }
-        )
+        entry: dict[str, Any] = {
+            "id": d.name,
+            "label": label,
+            "original_name": original_name,
+            "mtime": ply.stat().st_mtime,
+        }
+        if (d / "splat.spz").is_file():
+            entry["spz_url"] = f"/api/scenes/{d.name}/splat.spz"
+        scenes.append(entry)
     scenes.sort(key=lambda s: s["mtime"], reverse=True)
     for s in scenes:
         del s["mtime"]
@@ -182,6 +210,16 @@ def get_splat(scene_id: str) -> Any:
     if not ply.is_file():
         return jsonify({"error": "Not found"}), 404
     return send_file(ply, mimetype="application/octet-stream", as_attachment=False)
+
+
+@app.route("/api/scenes/<scene_id>/splat.spz", methods=["GET"])
+def get_splat_spz(scene_id: str) -> Any:
+    if not _scene_id_ok(scene_id):
+        return jsonify({"error": "Invalid scene id"}), 400
+    spz = OUTPUTS_DIR / scene_id / "splat.spz"
+    if not spz.is_file():
+        return jsonify({"error": "Not found"}), 404
+    return send_file(spz, mimetype="application/octet-stream", as_attachment=False)
 
 
 @app.route("/api/generate", methods=["POST"])
@@ -232,22 +270,27 @@ def generate() -> Any:
             pass
         return jsonify({"error": "Inference failed; check server logs."}), 500
 
+    spz_path = scene_dir / "splat.spz"
+    has_spz = _export_sharp_ply_to_spz(ply_path, spz_path)
+
     meta = {
         "id": scene_id,
         "original_name": upload.filename,
         "created": datetime.now(timezone.utc).isoformat(),
         "width": width,
         "height": height,
+        "has_spz": has_spz,
     }
     (scene_dir / "meta.json").write_text(json.dumps(meta, indent=2), encoding="utf-8")
 
-    return jsonify(
-        {
-            "id": scene_id,
-            "ply_url": f"/api/scenes/{scene_id}/splat.ply",
-            "label": upload.filename,
-        }
-    )
+    payload: dict[str, Any] = {
+        "id": scene_id,
+        "ply_url": f"/api/scenes/{scene_id}/splat.ply",
+        "label": upload.filename,
+    }
+    if has_spz:
+        payload["spz_url"] = f"/api/scenes/{scene_id}/splat.spz"
+    return jsonify(payload)
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -121,7 +121,9 @@ def _export_sharp_ply_to_spz(ply_path: Path, spz_path: Path) -> bool:
         import gaussforge
         from plyfile import PlyData, PlyElement
     except ImportError:
-        LOGGER.warning("gaussforge or plyfile missing; install requirements.txt for .spz export")
+        LOGGER.warning(
+            "gaussforge or plyfile not importable; run: pip install -e ./ml-sharp -r requirements.txt"
+        )
         return False
     try:
         plydata = PlyData.read(str(ply_path))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 flask>=3.0.0
+gaussforge>=0.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask>=3.0.0
 gaussforge>=0.5.3
+plyfile


### PR DESCRIPTION
## Description

This pull request adds support for exporting SHARP-generated `.ply` files to the Niantic `.spz` format using GaussForge, and exposes these `.spz` files via the API when available. The documentation is updated to reflect the new SPZ export capability and its requirements. The most important changes are grouped below.
