### PR TITLE
GH-5: Allow limiting splat count

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,10 +118,34 @@ def _scene_id_ok(scene_id: str) -> bool:
 
 
 def _count_ply_vertices(ply_path: Path) -> int:
-    from plyfile import PlyData
+    """Vertex count from the PLY header only (no full file decode).
 
-    plydata = PlyData.read(str(ply_path))
-    return int(plydata["vertex"].count)
+    SHARP splats can be huge; PlyData.read would parse every vertex just to
+    read ``element vertex N`` in the ASCII header before ``end_header``.
+    """
+    vertex_count: Optional[int] = None
+    with ply_path.open("r", encoding="ascii", errors="replace") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line:
+                continue
+            if line == "end_header":
+                break
+            parts = line.split()
+            if (
+                len(parts) == 3
+                and parts[0] == "element"
+                and parts[1] == "vertex"
+            ):
+                try:
+                    vertex_count = int(parts[2])
+                except ValueError:
+                    pass
+    if vertex_count is None:
+        raise ValueError(
+            f"PLY header missing valid 'element vertex N' before end_header: {ply_path}"
+        )
+    return vertex_count
 
 
 def _decimate_ply_splat_transform(

--- a/app.py
+++ b/app.py
@@ -28,7 +28,7 @@ import threading
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional, Tuple
+from typing import Any, Optional
 
 from flask import Flask, jsonify, request, send_file, send_from_directory
 
@@ -168,7 +168,7 @@ def _decimate_ply_splat_transform(
         return False
 
 
-def _parse_splat_limit_form() -> Tuple[bool, Optional[int], Optional[str]]:
+def _parse_splat_limit_form() -> tuple[bool, Optional[int], Optional[str]]:
     """From multipart form: (limit_enabled, max_splats or None, error message or None)."""
     flag = (request.form.get("limit_splats") or "").strip().lower()
     active = flag in ("1", "true", "on", "yes")

--- a/app.py
+++ b/app.py
@@ -22,11 +22,13 @@ from __future__ import annotations
 import io
 import json
 import logging
+import shutil
+import subprocess
 import threading
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Tuple
 
 from flask import Flask, jsonify, request, send_file, send_from_directory
 
@@ -115,6 +117,78 @@ def _scene_id_ok(scene_id: str) -> bool:
         return False
 
 
+def _count_ply_vertices(ply_path: Path) -> int:
+    from plyfile import PlyData
+
+    plydata = PlyData.read(str(ply_path))
+    return int(plydata["vertex"].count)
+
+
+def _decimate_ply_splat_transform(
+    ply_path: Path, target_count: int, timeout_sec: int = 7200
+) -> bool:
+    """Decimate in place via PlayCanvas splat-transform (full PLY must exist)."""
+    exe = shutil.which("splat-transform")
+    if not exe:
+        LOGGER.warning(
+            "splat-transform not on PATH; install: npm install -g @playcanvas/splat-transform"
+        )
+        return False
+    tmp_out = ply_path.with_name("_splat_decimated_tmp.ply")
+    try:
+        tmp_out.unlink(missing_ok=True)
+        cmd = [exe, str(ply_path), "--decimate", str(target_count), str(tmp_out)]
+        r = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_sec,
+        )
+        if r.returncode != 0:
+            err = (r.stderr or r.stdout or "").strip()
+            LOGGER.warning(
+                "splat-transform failed (exit %s): %s",
+                r.returncode,
+                err[:2000] if err else "(no output)",
+            )
+            tmp_out.unlink(missing_ok=True)
+            return False
+        if not tmp_out.is_file():
+            LOGGER.warning("splat-transform produced no output file")
+            return False
+        tmp_out.replace(ply_path)
+        return True
+    except subprocess.TimeoutExpired:
+        LOGGER.warning("splat-transform timed out after %s s", timeout_sec)
+        tmp_out.unlink(missing_ok=True)
+        return False
+    except OSError as e:
+        LOGGER.warning("splat-transform output handling failed: %s", e)
+        tmp_out.unlink(missing_ok=True)
+        return False
+
+
+def _parse_splat_limit_form() -> Tuple[bool, Optional[int], Optional[str]]:
+    """From multipart form: (limit_enabled, max_splats or None, error message or None)."""
+    flag = (request.form.get("limit_splats") or "").strip().lower()
+    active = flag in ("1", "true", "on", "yes")
+    if not active:
+        return False, None, None
+    raw = (request.form.get("max_splats") or "").strip()
+    if not raw:
+        return True, None, "max_splats is required when limit splats is enabled"
+    try:
+        n = int(raw, 10)
+    except ValueError:
+        return True, None, "max_splats must be an integer"
+    if n < 1:
+        return True, None, "max_splats must be at least 1"
+    cap = 10_000_000
+    if n > cap:
+        return True, None, f"max_splats cannot exceed {cap:,}"
+    return True, n, None
+
+
 def _export_sharp_ply_to_spz(ply_path: Path, spz_path: Path) -> bool:
     """Write Niantic-style .spz from SHARP splat.ply (vertex-only PLY for GaussForge)."""
     try:
@@ -181,6 +255,7 @@ def list_scenes() -> Any:
         meta_path = d / "meta.json"
         label = d.name[:8] + "…"
         original_name = ""
+        meta: dict[str, Any] = {}
         if meta_path.is_file():
             try:
                 meta = json.loads(meta_path.read_text(encoding="utf-8"))
@@ -188,13 +263,21 @@ def list_scenes() -> Any:
                 if original_name:
                     label = original_name
             except (json.JSONDecodeError, OSError):
-                pass
+                meta = {}
         entry: dict[str, Any] = {
             "id": d.name,
             "label": label,
             "original_name": original_name,
             "mtime": ply.stat().st_mtime,
         }
+        if "splat_count" in meta:
+            entry["splat_count"] = meta["splat_count"]
+        if "splat_count_full" in meta:
+            entry["splat_count_full"] = meta["splat_count_full"]
+        if meta.get("splat_limit_applied"):
+            entry["splat_limit_applied"] = True
+        if meta.get("decimate_error"):
+            entry["decimate_error"] = meta["decimate_error"]
         if (d / "splat.spz").is_file():
             entry["spz_url"] = f"/api/scenes/{d.name}/splat.spz"
         scenes.append(entry)
@@ -243,6 +326,10 @@ def generate() -> Any:
     if ext not in allowed:
         return jsonify({"error": f"Unsupported image type: {ext or '(none)'}"}), 400
 
+    limit_on, max_splats, limit_err = _parse_splat_limit_form()
+    if limit_err:
+        return jsonify({"error": limit_err}), 400
+
     OUTPUTS_DIR.mkdir(parents=True, exist_ok=True)
     scene_id = str(uuid.uuid4())
     scene_dir = OUTPUTS_DIR / scene_id
@@ -265,12 +352,26 @@ def generate() -> Any:
     except Exception:
         LOGGER.exception("Inference failed for %s", input_path)
         try:
-            import shutil
-
             shutil.rmtree(scene_dir, ignore_errors=True)
         except OSError:
             pass
         return jsonify({"error": "Inference failed; check server logs."}), 500
+
+    splat_count_full = _count_ply_vertices(ply_path)
+    splat_count = splat_count_full
+    limit_applied = False
+    decimate_error: Optional[str] = None
+
+    if limit_on and max_splats is not None:
+        if splat_count_full > max_splats:
+            if _decimate_ply_splat_transform(ply_path, max_splats):
+                splat_count = _count_ply_vertices(ply_path)
+                limit_applied = splat_count < splat_count_full
+            else:
+                decimate_error = (
+                    "Decimation failed or splat-transform missing; "
+                    "install: npm install -g @playcanvas/splat-transform"
+                )
 
     spz_path = scene_dir / "splat.spz"
     has_spz = _export_sharp_ply_to_spz(ply_path, spz_path)
@@ -282,14 +383,24 @@ def generate() -> Any:
         "width": width,
         "height": height,
         "has_spz": has_spz,
+        "splat_count": splat_count,
+        "splat_count_full": splat_count_full,
+        "splat_limit_applied": limit_applied,
     }
+    if decimate_error:
+        meta["decimate_error"] = decimate_error
     (scene_dir / "meta.json").write_text(json.dumps(meta, indent=2), encoding="utf-8")
 
     payload: dict[str, Any] = {
         "id": scene_id,
         "ply_url": f"/api/scenes/{scene_id}/splat.ply",
         "label": upload.filename,
+        "splat_count": splat_count,
+        "splat_count_full": splat_count_full,
+        "splat_limit_applied": limit_applied,
     }
+    if decimate_error:
+        payload["decimate_error"] = decimate_error
     if has_spz:
         payload["spz_url"] = f"/api/scenes/{scene_id}/splat.spz"
     return jsonify(payload)

--- a/static/index.html
+++ b/static/index.html
@@ -35,6 +35,32 @@
             <img id="previewImg" class="preview-img hidden" alt="" />
           </div>
         </div>
+        <div class="splat-limit-row" role="group" aria-label="Splat count limit">
+          <label class="splat-limit-check">
+            <input type="checkbox" id="limitSplatsCheck" />
+            <span>Limit splat count</span>
+          </label>
+          <input
+            type="number"
+            id="maxSplatsInput"
+            class="splat-limit-input"
+            min="1"
+            max="10000000"
+            value="500000"
+            step="1"
+            disabled
+            aria-label="Maximum splats when limiting"
+          />
+        </div>
+        <p class="hint splat-limit-hint">
+          Full-quality PLY is written first, then
+          <a href="https://www.npmjs.com/package/@playcanvas/splat-transform" target="_blank" rel="noopener"
+            >splat-transform</a
+          >
+          decimates (pairwise merge). Requires <code>splat-transform</code> on PATH (<code
+            >npm i -g @playcanvas/splat-transform</code
+          >).
+        </p>
         <button type="button" class="btn btn-primary" id="btnGenerate" disabled>Generate</button>
         <div class="status-bar" id="statusBar" role="status">Ready</div>
         <p class="hint">Inference runs locally via Python (PyTorch). First run downloads the model.</p>
@@ -48,6 +74,7 @@
             <p>Generate to preview</p>
           </div>
         </div>
+        <p class="splat-info" id="splatInfo" aria-live="polite">Splats: —</p>
         <label class="control-label" for="splatScale">Splat size</label>
         <input type="range" id="splatScale" class="range" min="0.25" max="3" step="0.05" value="1" disabled />
         <p class="hint hint-keys">Arrow keys: ↑ or → forward · ↓ or ← back (dolly along view)</p>

--- a/static/main.js
+++ b/static/main.js
@@ -11,6 +11,9 @@ const viewerPlaceholder = document.getElementById("viewerPlaceholder");
 const sceneSelect = document.getElementById("sceneSelect");
 const btnFullscreen = document.getElementById("btnFullscreen");
 const splatScale = document.getElementById("splatScale");
+const limitSplatsCheck = document.getElementById("limitSplatsCheck");
+const maxSplatsInput = document.getElementById("maxSplatsInput");
+const splatInfo = document.getElementById("splatInfo");
 
 /** World-units per key press (fly mode); orbit mode scales slightly with distance. */
 const DOLLY_BASE = 0.14;
@@ -26,6 +29,50 @@ function setStatus(text, kind = "") {
   statusBar.textContent = text;
   statusBar.classList.remove("error", "working");
   if (kind) statusBar.classList.add(kind);
+}
+
+function formatSplatLine(count, full, limited) {
+  const c = Number(count).toLocaleString();
+  if (limited && full != null && Number(full) > Number(count)) {
+    return `Splats: ${c} (capped from ${Number(full).toLocaleString()})`;
+  }
+  return `Splats: ${c}`;
+}
+
+function setSplatInfoFromApi(data) {
+  if (!splatInfo || data.splat_count == null) return;
+  let text = formatSplatLine(
+    data.splat_count,
+    data.splat_count_full,
+    Boolean(data.splat_limit_applied)
+  );
+  if (data.decimate_error) {
+    text += ` — ${data.decimate_error}`;
+  }
+  splatInfo.textContent = text;
+}
+
+function setSplatInfoFromSelect() {
+  if (!splatInfo) return;
+  const opt = sceneSelect.selectedOptions[0];
+  if (!opt || !opt.value) {
+    splatInfo.textContent = "Splats: —";
+    return;
+  }
+  const c = opt.dataset.splatCount;
+  if (c === undefined || c === "") {
+    splatInfo.textContent = "Splats: —";
+    return;
+  }
+  let text = formatSplatLine(
+    Number(c),
+    opt.dataset.splatCountFull ? Number(opt.dataset.splatCountFull) : null,
+    opt.dataset.splatLimited === "1"
+  );
+  if (opt.dataset.decimateError) {
+    text += ` — ${opt.dataset.decimateError}`;
+  }
+  splatInfo.textContent = text;
 }
 
 async function disposeViewer() {
@@ -204,10 +251,20 @@ fileInput.addEventListener("change", () => {
   setPreviewFile(f || null);
 });
 
+limitSplatsCheck.addEventListener("change", () => {
+  maxSplatsInput.disabled = !limitSplatsCheck.checked;
+});
+
 btnGenerate.addEventListener("click", async () => {
   if (!currentFile) return;
   const fd = new FormData();
   fd.append("file", currentFile, currentFile.name);
+  if (limitSplatsCheck.checked) {
+    fd.append("limit_splats", "1");
+    const raw = parseInt(maxSplatsInput.value, 10);
+    const n = Number.isFinite(raw) && raw >= 1 ? Math.min(raw, 10_000_000) : 500_000;
+    fd.append("max_splats", String(n));
+  }
   setStatus("Generating…", "working");
   btnGenerate.disabled = true;
   try {
@@ -219,6 +276,7 @@ btnGenerate.addEventListener("click", async () => {
       return;
     }
     setStatus("Ready");
+    setSplatInfoFromApi(data);
     await loadSplatUrl(data.ply_url);
     await refreshScenes(data.id);
     btnGenerate.disabled = false;
@@ -231,11 +289,16 @@ btnGenerate.addEventListener("click", async () => {
 
 sceneSelect.addEventListener("change", async () => {
   const id = sceneSelect.value;
-  if (!id) return;
+  if (!id) {
+    if (splatInfo) splatInfo.textContent = "Splats: —";
+    return;
+  }
+  setSplatInfoFromSelect();
   setStatus("Loading scene…", "working");
   try {
     await loadSplatUrl(`/api/scenes/${id}/splat.ply`);
     setStatus("Ready");
+    setSplatInfoFromSelect();
   } catch (err) {
     console.error(err);
     setStatus("Failed to load scene", "error");
@@ -261,6 +324,12 @@ async function refreshScenes(selectId = null) {
       const opt = document.createElement("option");
       opt.value = s.id;
       opt.textContent = s.label || s.id;
+      if (s.splat_count != null) {
+        opt.dataset.splatCount = String(s.splat_count);
+        if (s.splat_count_full != null) opt.dataset.splatCountFull = String(s.splat_count_full);
+        if (s.splat_limit_applied) opt.dataset.splatLimited = "1";
+        if (s.decimate_error) opt.dataset.decimateError = s.decimate_error;
+      }
       sceneSelect.appendChild(opt);
     }
     if (selectId) {

--- a/static/main.js
+++ b/static/main.js
@@ -251,9 +251,13 @@ fileInput.addEventListener("change", () => {
   setPreviewFile(f || null);
 });
 
-limitSplatsCheck.addEventListener("change", () => {
+function syncMaxSplatsInputDisabled() {
+  if (!limitSplatsCheck || !maxSplatsInput) return;
   maxSplatsInput.disabled = !limitSplatsCheck.checked;
-});
+}
+
+limitSplatsCheck.addEventListener("change", syncMaxSplatsInputDisabled);
+syncMaxSplatsInputDisabled();
 
 btnGenerate.addEventListener("click", async () => {
   if (!currentFile) return;

--- a/static/style.css
+++ b/static/style.css
@@ -130,6 +130,60 @@ body {
   display: none;
 }
 
+.splat-limit-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.splat-limit-check {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.splat-limit-check input {
+  accent-color: var(--accent);
+  width: 1rem;
+  height: 1rem;
+}
+
+.splat-limit-input {
+  flex: 1;
+  min-width: 6rem;
+  max-width: 10rem;
+  padding: 0.5rem 0.65rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--panel-border);
+  background: #1a1a1a;
+  color: var(--text);
+  font-size: 0.85rem;
+}
+
+.splat-limit-input:focus {
+  outline: 1px solid #444;
+}
+
+.splat-limit-input:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.splat-limit-hint {
+  margin: -0.35rem 0 0;
+}
+
+.splat-info {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
 .btn {
   border: none;
   border-radius: var(--radius-sm);


### PR DESCRIPTION
## Description

This pull request adds a user-selectable limit on the number of splats (points) generated in the 3D reconstruction process, both in the backend (`app.py`) and the frontend UI. It introduces server-side enforcement of the splat count cap using the `splat-transform` tool, exposes relevant metadata and errors to the client, and updates the UI to allow users to set and view splat limits and results.
