### PR TITLE
GH-7: Add batch folder tool and shared SHARP core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ outputs/
 __pycache__/
 *.pyc
 .venv/
+build/
+dist/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ Open **http://127.0.0.1:8765**
 
 The first run downloads the SHARP checkpoint (~2.6 GB) into `~/.cache/torch/hub/checkpoints/`.
 
+### Batch folder tool (`sharp_local_batch`)
+
+**GUI:** uses **PySide6-Essentials** (Qt widgets only; smaller than the full `PySide6` metapackage that also downloads Addons). Falls back to **Tk** if it is missing. **CLI** needs no GUI toolkit.
+
+```bash
+python -m sharp_local_batch
+python -m sharp_local_batch --cli --folder /path/to/photos --recursive
+```
+
+**Homebrew Python without `_tkinter`:** use **PySide6-Essentials** from requirements; or `brew install python-tk@3.14` (match your Python minor) and recreate `.venv`; or use `--cli`.
+
+**Standalone build (PyInstaller):** with the repo venv active and `ml-sharp` present, run `pip install pyinstaller` then `pyinstaller packaging/sharp_batch.spec` from the repo root. The bundle is **`dist/SharpBatch/`** (large: PyTorch + Qt). Run `./dist/SharpBatch/SharpBatch` (add `--cli …` for headless). First inference still downloads the SHARP weights into the user cache unless you ship them separately.
+
 ## Using the UI
 
 1. Drop an image (or browse). HEIC is supported if `pillow-heif` is installed (comes with ml-sharp).

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ python -m sharp_local_batch --cli --folder ~/Pictures/Photos\ Library.photoslibr
   --recursive --output-root /path/to/splat_mirror
 ```
 
-On **macOS**, the GUI can enable **Use Apple Photos library bundle** — scan/watch always use **`~/Pictures/Photos Library.photoslibrary`** (the system library package) while that option is on, with mirrored PLY output; pick a **target folder for mirror** outside that bundle. Images are collected from **`originals/`** (or older libraries **`Masters/`**) inside the package, same as **`backend/api.py`** iCloud discovery — not only the bundle root. For the CLI, any **`.photoslibrary`** path passed to **`--folder`** requires **`--output-root`** and uses the same rules.
+On **macOS**, the GUI can enable **Use system Photos library as source folder** — that **replaces** the main folder path (one source per run, not an extra directory); scan/watch use **`~/Pictures/Photos Library.photoslibrary`** while it is on, with mirrored PLY output; pick a **target folder for mirror** outside that bundle. Uncheck it to browse any other folder. Images are collected from **`originals/`** (or older libraries **`Masters/`**) inside the package, same as **`backend/api.py`** iCloud discovery — not only the bundle root. For the CLI, any **`.photoslibrary`** path passed to **`--folder`** requires **`--output-root`** and uses the same rules.
 
 In the GUI, enable **Mirror PLY output** and pick a **target folder for mirror** (must differ from the source folder). Default remains **next to each image**. For images under your home folder, mirrored PLY paths repeat from home (e.g. **`Pictures/Photos Library.photoslibrary/originals/…`**) instead of only **`originals/…`**; sources outside home still mirror relative to the chosen source root.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,17 @@ The first run downloads the SHARP checkpoint (~2.6 GB) into `~/.cache/torch/hu
 ```bash
 python -m sharp_local_batch
 python -m sharp_local_batch --cli --folder /path/to/photos --recursive
+# PLY under another tree (under ~: path from home, e.g. Pictures/…; else relative to --folder):
+python -m sharp_local_batch --cli --folder /path/to/photos --recursive \
+  --output-root /path/to/splat_mirror
+# macOS system library (PLY must not be written inside the bundle — mirror required):
+python -m sharp_local_batch --cli --folder ~/Pictures/Photos\ Library.photoslibrary \
+  --recursive --output-root /path/to/splat_mirror
 ```
+
+On **macOS**, the GUI can enable **Use Apple Photos library bundle** — scan/watch always use **`~/Pictures/Photos Library.photoslibrary`** (the system library package) while that option is on, with mirrored PLY output; pick a **target folder for mirror** outside that bundle. Images are collected from **`originals/`** (or older libraries **`Masters/`**) inside the package, same as **`backend/api.py`** iCloud discovery — not only the bundle root. For the CLI, any **`.photoslibrary`** path passed to **`--folder`** requires **`--output-root`** and uses the same rules.
+
+In the GUI, enable **Mirror PLY output** and pick a **target folder for mirror** (must differ from the source folder). Default remains **next to each image**. For images under your home folder, mirrored PLY paths repeat from home (e.g. **`Pictures/Photos Library.photoslibrary/originals/…`**) instead of only **`originals/…`**; sources outside home still mirror relative to the chosen source root.
 
 **Homebrew Python without `_tkinter`:** use **PySide6-Essentials** from requirements; or `brew install python-tk@3.14` (match your Python minor) and recreate `.venv`; or use `--cli`.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The first run downloads the SHARP checkpoint (~2.6 GB) into `~/.cache/torch/hu
 **GUI:** uses **PySide6-Essentials** (Qt widgets only; smaller than the full `PySide6` metapackage that also downloads Addons). Falls back to **Tk** if it is missing. **CLI** needs no GUI toolkit.
 
 ```bash
+source .venv/bin/activate
 python -m sharp_local_batch
 python -m sharp_local_batch --cli --folder /path/to/photos --recursive
 # PLY under another tree (under ~: path from home, e.g. Pictures/…; else relative to --folder):

--- a/app.py
+++ b/app.py
@@ -23,8 +23,6 @@ import io
 import json
 import logging
 import shutil
-import subprocess
-import threading
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -32,8 +30,18 @@ from typing import Any, Optional
 
 from flask import Flask, jsonify, request, send_file, send_from_directory
 
+from sharp_local_batch.core import (
+    ML_SHARP_SRC,
+    PREDICT_LOCK,
+    count_ply_vertices,
+    decimate_ply_splat_transform,
+    ensure_sharp_imports,
+    get_predictor,
+    inference_device,
+    predictor_loaded,
+)
+
 EXPERIMENT_ROOT = Path(__file__).resolve().parent
-ML_SHARP_SRC = EXPERIMENT_ROOT / "ml-sharp" / "src"
 OUTPUTS_DIR = EXPERIMENT_ROOT / "outputs"
 STATIC_DIR = EXPERIMENT_ROOT / "static"
 
@@ -55,58 +63,8 @@ LOGGER = _configure_logger("sharp-web")
 logging.getLogger("matplotlib").setLevel(logging.WARNING)
 logging.getLogger("matplotlib.font_manager").setLevel(logging.WARNING)
 
-if ML_SHARP_SRC.is_dir():
-    import sys
-
-    sys.path.insert(0, str(ML_SHARP_SRC))
-else:
-    LOGGER.warning(
-        "ml-sharp not found at %s — run: git submodule update --init ml-sharp",
-        ML_SHARP_SRC.parent,
-    )
-
 app = Flask(__name__, static_folder=str(STATIC_DIR), static_url_path="")
 app.config["MAX_CONTENT_LENGTH"] = 64 * 1024 * 1024
-
-_predict_lock = threading.Lock()
-_predictor: Any = None
-_device: Optional[str] = None
-
-
-def _ensure_sharp_imports() -> None:
-    if not ML_SHARP_SRC.is_dir():
-        raise RuntimeError(
-            f"ml-sharp missing at {ML_SHARP_SRC}. From the repo root run: "
-            "git submodule update --init ml-sharp or ./bootstrap.sh (see README)."
-        )
-    import sharp  # noqa: F401
-
-
-def get_predictor() -> tuple[Any, str]:
-    global _predictor, _device
-    _ensure_sharp_imports()
-    if _predictor is not None and _device is not None:
-        return _predictor, _device
-
-    import torch
-    from sharp.cli.predict import DEFAULT_MODEL_URL
-    from sharp.models import PredictorParams, create_predictor
-
-    if torch.cuda.is_available():
-        _device = "cuda"
-    elif torch.mps.is_available():
-        _device = "mps"
-    else:
-        _device = "cpu"
-
-    LOGGER.info("Loading SHARP checkpoint (first run may download weights) on %s", _device)
-    state_dict = torch.hub.load_state_dict_from_url(DEFAULT_MODEL_URL, progress=True)
-    predictor = create_predictor(PredictorParams())
-    predictor.load_state_dict(state_dict)
-    predictor.eval()
-    predictor.to(_device)
-    _predictor = predictor
-    return _predictor, _device
 
 
 def _scene_id_ok(scene_id: str) -> bool:
@@ -114,81 +72,6 @@ def _scene_id_ok(scene_id: str) -> bool:
         uuid.UUID(scene_id)
         return True
     except ValueError:
-        return False
-
-
-def _count_ply_vertices(ply_path: Path) -> int:
-    """Vertex count from the PLY header only (no full file decode).
-
-    SHARP splats can be huge; PlyData.read would parse every vertex just to
-    read ``element vertex N`` in the ASCII header before ``end_header``.
-    """
-    vertex_count: Optional[int] = None
-    with ply_path.open("r", encoding="ascii", errors="replace") as f:
-        for raw in f:
-            line = raw.strip()
-            if not line:
-                continue
-            if line == "end_header":
-                break
-            parts = line.split()
-            if (
-                len(parts) == 3
-                and parts[0] == "element"
-                and parts[1] == "vertex"
-            ):
-                try:
-                    vertex_count = int(parts[2])
-                except ValueError:
-                    pass
-    if vertex_count is None:
-        raise ValueError(
-            f"PLY header missing valid 'element vertex N' before end_header: {ply_path}"
-        )
-    return vertex_count
-
-
-def _decimate_ply_splat_transform(
-    ply_path: Path, target_count: int, timeout_sec: int = 7200
-) -> bool:
-    """Decimate in place via PlayCanvas splat-transform (full PLY must exist)."""
-    exe = shutil.which("splat-transform")
-    if not exe:
-        LOGGER.warning(
-            "splat-transform not on PATH; install: npm install -g @playcanvas/splat-transform"
-        )
-        return False
-    tmp_out = ply_path.with_name("_splat_decimated_tmp.ply")
-    try:
-        tmp_out.unlink(missing_ok=True)
-        cmd = [exe, str(ply_path), "--decimate", str(target_count), str(tmp_out)]
-        r = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=timeout_sec,
-        )
-        if r.returncode != 0:
-            err = (r.stderr or r.stdout or "").strip()
-            LOGGER.warning(
-                "splat-transform failed (exit %s): %s",
-                r.returncode,
-                err[:2000] if err else "(no output)",
-            )
-            tmp_out.unlink(missing_ok=True)
-            return False
-        if not tmp_out.is_file():
-            LOGGER.warning("splat-transform produced no output file")
-            return False
-        tmp_out.replace(ply_path)
-        return True
-    except subprocess.TimeoutExpired:
-        LOGGER.warning("splat-transform timed out after %s s", timeout_sec)
-        tmp_out.unlink(missing_ok=True)
-        return False
-    except OSError as e:
-        LOGGER.warning("splat-transform output handling failed: %s", e)
-        tmp_out.unlink(missing_ok=True)
         return False
 
 
@@ -260,8 +143,8 @@ def health() -> Any:
             "ok": True,
             "ml_sharp_path": str(ML_SHARP_SRC),
             "ml_sharp_present": ok,
-            "model_loaded": _predictor is not None,
-            "device": _device,
+            "model_loaded": predictor_loaded(),
+            "device": inference_device(),
         }
     )
 
@@ -339,7 +222,7 @@ def generate() -> Any:
     if not upload.filename:
         return jsonify({"error": "Empty filename"}), 400
 
-    _ensure_sharp_imports()
+    ensure_sharp_imports()
     from sharp.utils import io as sharp_io
     from sharp.utils.gaussians import save_ply
 
@@ -365,7 +248,7 @@ def generate() -> Any:
     import torch
 
     try:
-        with _predict_lock:
+        with PREDICT_LOCK:
             predictor, device_str = get_predictor()
             image, _, f_px = sharp_io.load_rgb(input_path)
             height, width = int(image.shape[0]), int(image.shape[1])
@@ -381,15 +264,15 @@ def generate() -> Any:
             pass
         return jsonify({"error": "Inference failed; check server logs."}), 500
 
-    splat_count_full = _count_ply_vertices(ply_path)
+    splat_count_full = count_ply_vertices(ply_path)
     splat_count = splat_count_full
     limit_applied = False
     decimate_error: Optional[str] = None
 
     if limit_on and max_splats is not None:
         if splat_count_full > max_splats:
-            if _decimate_ply_splat_transform(ply_path, max_splats):
-                splat_count = _count_ply_vertices(ply_path)
+            if decimate_ply_splat_transform(ply_path, max_splats):
+                splat_count = count_ply_vertices(ply_path)
                 limit_applied = splat_count < splat_count_full
             else:
                 decimate_error = (

--- a/app.py
+++ b/app.py
@@ -30,6 +30,10 @@ from typing import Any, Optional
 
 from flask import Flask, jsonify, request, send_file, send_from_directory
 
+from sharp_local_batch.logging_config import ensure_stderr_info_logging
+
+ensure_stderr_info_logging()
+
 from sharp_local_batch.core import (
     ML_SHARP_SRC,
     PREDICT_LOCK,

--- a/packaging/entry_batch.py
+++ b/packaging/entry_batch.py
@@ -1,0 +1,16 @@
+"""PyInstaller entrypoint: run ``python -m sharp_local_batch`` (GUI or --cli)."""
+
+from __future__ import annotations
+
+import multiprocessing
+
+
+def main() -> None:
+    from sharp_local_batch.__main__ import main as batch_main
+
+    batch_main()
+
+
+if __name__ == "__main__":
+    multiprocessing.freeze_support()
+    main()

--- a/packaging/sharp_batch.spec
+++ b/packaging/sharp_batch.spec
@@ -1,0 +1,100 @@
+# -*- mode: python ; coding: utf-8 -*-
+#
+# Build a standalone app for sharp_local_batch (Qt GUI + CLI).
+#
+# From the repository root (with .venv activated and deps installed):
+#   pip install pyinstaller
+#   pyinstaller packaging/sharp_batch.spec
+#
+# Output: dist/SharpBatch/  (macOS: SharpBatch.app if you add --windowed; this spec uses console for CLI.)
+#
+# Expect a large bundle (PyTorch + Qt). The SHARP checkpoint still downloads on first inference
+# unless you ship it separately and point TORCH_HOME / cache.
+#
+import pathlib
+
+from PyInstaller.utils.hooks import collect_submodules, copy_metadata
+
+block_cipher = None
+
+REPO = pathlib.Path(SPECPATH).resolve().parent
+
+datas = []
+if (REPO / "ml-sharp" / "src").is_dir():
+    datas.append((str(REPO / "ml-sharp" / "src"), "ml-sharp/src"))
+
+# imageio reads importlib.metadata.version("imageio") at import time; frozen apps omit dist-info otherwise.
+datas += copy_metadata("imageio")
+try:
+    datas += copy_metadata("imageio-ffmpeg")
+except Exception:
+    pass
+
+hiddenimports = (
+    collect_submodules("sharp")
+    + [
+        "sharp_local_batch",
+        "sharp_local_batch.core",
+        "sharp_local_batch.batch_runner",
+        "sharp_local_batch.gui_qt",
+        "sharp_local_batch.gui",
+        "watchdog",
+        "watchdog.observers",
+        "watchdog.events",
+        "plyfile",
+        "PIL",
+        "PIL.Image",
+        "gaussforge",
+        "imageio",
+        "imageio.v2",
+        "imageio.core",
+        "imageio.plugins",
+    ]
+)
+
+a = Analysis(
+    [str(REPO / "packaging" / "entry_batch.py")],
+    pathex=[str(REPO)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="SharpBatch",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="SharpBatch",
+)

--- a/packaging/sharp_batch.spec
+++ b/packaging/sharp_batch.spec
@@ -30,6 +30,8 @@ try:
 except Exception:
     pass
 
+# Omit sharp_local_batch.gui: frozen bundle targets PySide6 only; Tk needs _tkinter
+# and breaks analysis/build on Homebrew Pythons without Tcl/Tk.
 hiddenimports = (
     collect_submodules("sharp")
     + [
@@ -37,7 +39,7 @@ hiddenimports = (
         "sharp_local_batch.core",
         "sharp_local_batch.batch_runner",
         "sharp_local_batch.gui_qt",
-        "sharp_local_batch.gui",
+        "sharp_local_batch.logging_config",
         "watchdog",
         "watchdog.observers",
         "watchdog.events",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 flask>=3.0.0
 gaussforge>=0.5.3
 plyfile
+watchdog>=4.0.0
+PySide6-Essentials>=6.7.0

--- a/sharp_local_batch/__init__.py
+++ b/sharp_local_batch/__init__.py
@@ -1,0 +1,3 @@
+"""Batch and filesystem-watch SHARP splat generation (PLY next to each image)."""
+
+__all__ = ["core"]

--- a/sharp_local_batch/__init__.py
+++ b/sharp_local_batch/__init__.py
@@ -1,3 +1,3 @@
-"""Batch and filesystem-watch SHARP splat generation (PLY next to each image)."""
+"""Batch and filesystem-watch SHARP splat generation (PLY beside images or mirrored)."""
 
 __all__ = ["core"]

--- a/sharp_local_batch/__main__.py
+++ b/sharp_local_batch/__main__.py
@@ -82,14 +82,20 @@ def _cli_main() -> int:
         print("Use: --output-root /path/outside/library", file=sys.stderr)
         return 1
 
-    jobs = scan_jobs(
+    jobs, total_found = scan_jobs(
         root,
         args.recursive,
         force_all=args.force_all,
         mirror_output_root=mirror_out,
     )
     if not jobs:
-        print("No images need processing.")
+        if total_found == 0:
+            print(
+                "No supported images found under the source folder.",
+                file=sys.stderr,
+            )
+        else:
+            print("No images need processing (PLY already up to date).")
         return 0
 
     max_s = args.max_splats if args.limit_splats else None

--- a/sharp_local_batch/__main__.py
+++ b/sharp_local_batch/__main__.py
@@ -139,6 +139,15 @@ Fix (pick one):
 """
 
 
+def _is_expected_missing_qt(exc: ImportError) -> bool:
+    """True only when PySide6 (or a PySide6.* submodule) is absent — not other import bugs."""
+    if isinstance(exc, ModuleNotFoundError):
+        name = (exc.name or "").lower()
+        if name == "pyside6" or name.startswith("pyside6."):
+            return True
+    return "pyside6" in str(exc).lower()
+
+
 def main() -> None:
     if len(sys.argv) >= 2 and sys.argv[1] == "--cli":
         sys.argv.pop(1)
@@ -148,8 +157,9 @@ def main() -> None:
 
         gui_main()
         return
-    except ImportError:
-        pass
+    except ImportError as e:
+        if not _is_expected_missing_qt(e):
+            raise
     try:
         from sharp_local_batch.gui import main as gui_main
 

--- a/sharp_local_batch/__main__.py
+++ b/sharp_local_batch/__main__.py
@@ -7,16 +7,26 @@ import sys
 from pathlib import Path
 
 from sharp_local_batch.batch_runner import scan_jobs
-from sharp_local_batch.core import process_image_to_sidecar_ply
+from sharp_local_batch.core import (
+    PHOTOS_LIBRARY_MIRROR_HELP,
+    is_photos_library_bundle,
+    output_ply_path_for_job,
+    process_image_to_sidecar_ply,
+)
 
 
 def _cli_main() -> int:
-    p = argparse.ArgumentParser(description="SHARP batch: PLY next to each image.")
+    p = argparse.ArgumentParser(
+        description="SHARP batch: PLY beside each image, or under --output-root when mirroring.",
+    )
     p.add_argument(
         "--folder",
         type=Path,
         required=True,
-        help="Root folder to scan",
+        help=(
+            "Root path to scan (a directory of images, or a macOS "
+            "Photos Library.photoslibrary bundle — the latter requires --output-root)"
+        ),
     )
     p.add_argument(
         "--recursive",
@@ -39,6 +49,15 @@ def _cli_main() -> int:
         default=500_000,
         help="Target splat count when --limit-splats (default 500000)",
     )
+    p.add_argument(
+        "--output-root",
+        type=Path,
+        default=None,
+        help=(
+            "Write PLY files under this folder; under ~ mirror path from home, else "
+            "relative to --folder (default: next to each image)"
+        ),
+    )
     args = p.parse_args()
 
     root = args.folder.expanduser().resolve()
@@ -46,7 +65,25 @@ def _cli_main() -> int:
         print(f"Not a directory: {root}", file=sys.stderr)
         return 1
 
-    jobs = scan_jobs(root, args.recursive, force_all=args.force_all)
+    mirror_out: Path | None = None
+    if args.output_root is not None:
+        mirror_out = args.output_root.expanduser().resolve()
+        if mirror_out == root:
+            print("--output-root must differ from --folder", file=sys.stderr)
+            return 1
+        mirror_out.mkdir(parents=True, exist_ok=True)
+
+    if is_photos_library_bundle(root) and mirror_out is None:
+        print(PHOTOS_LIBRARY_MIRROR_HELP, file=sys.stderr)
+        print("Use: --output-root /path/outside/library", file=sys.stderr)
+        return 1
+
+    jobs = scan_jobs(
+        root,
+        args.recursive,
+        force_all=args.force_all,
+        mirror_output_root=mirror_out,
+    )
     if not jobs:
         print("No images need processing.")
         return 0
@@ -60,10 +97,21 @@ def _cli_main() -> int:
     exit_code = 0
     for i, path in enumerate(jobs, start=1):
         print(f"[{i}/{n}] {path}", flush=True)
+        try:
+            ply_target = output_ply_path_for_job(
+                path,
+                mirror_output_root=mirror_out,
+                mirror_input_root=root if mirror_out is not None else None,
+            )
+        except ValueError as e:
+            print(f"    err: {e}", flush=True)
+            exit_code = 1
+            continue
         r = process_image_to_sidecar_ply(
             path,
             limit_splats=args.limit_splats,
             max_splats=max_s,
+            ply_output_path=ply_target,
         )
         tag = "ok" if r.ok else "err"
         if r.skipped:

--- a/sharp_local_batch/__main__.py
+++ b/sharp_local_batch/__main__.py
@@ -1,0 +1,114 @@
+"""Run ``python -m sharp_local_batch`` (GUI default) or ``--cli`` for headless."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from sharp_local_batch.batch_runner import scan_jobs
+from sharp_local_batch.core import process_image_to_sidecar_ply
+
+
+def _cli_main() -> int:
+    p = argparse.ArgumentParser(description="SHARP batch: PLY next to each image.")
+    p.add_argument(
+        "--folder",
+        type=Path,
+        required=True,
+        help="Root folder to scan",
+    )
+    p.add_argument(
+        "--recursive",
+        action="store_true",
+        help="Include subfolders",
+    )
+    p.add_argument(
+        "--force-all",
+        action="store_true",
+        help="Reprocess every image (ignore PLY freshness)",
+    )
+    p.add_argument(
+        "--limit-splats",
+        action="store_true",
+        help="Decimate with splat-transform after full PLY",
+    )
+    p.add_argument(
+        "--max-splats",
+        type=int,
+        default=500_000,
+        help="Target splat count when --limit-splats (default 500000)",
+    )
+    args = p.parse_args()
+
+    root = args.folder.expanduser().resolve()
+    if not root.is_dir():
+        print(f"Not a directory: {root}", file=sys.stderr)
+        return 1
+
+    jobs = scan_jobs(root, args.recursive, force_all=args.force_all)
+    if not jobs:
+        print("No images need processing.")
+        return 0
+
+    max_s = args.max_splats if args.limit_splats else None
+    if args.limit_splats and args.max_splats < 1:
+        print("--max-splats must be >= 1", file=sys.stderr)
+        return 1
+
+    n = len(jobs)
+    exit_code = 0
+    for i, path in enumerate(jobs, start=1):
+        print(f"[{i}/{n}] {path}", flush=True)
+        r = process_image_to_sidecar_ply(
+            path,
+            limit_splats=args.limit_splats,
+            max_splats=max_s,
+        )
+        tag = "ok" if r.ok else "err"
+        if r.skipped:
+            tag = "skip"
+        print(f"    {tag}: {r.message}", flush=True)
+        if not r.ok and not r.skipped:
+            exit_code = 1
+    return exit_code
+
+
+_GUI_HELP = """\
+No batch GUI available.
+
+Fix (pick one):
+  • pip install PySide6-Essentials
+    Then: python -m sharp_local_batch
+    (Qt UI; smaller than full PySide6; no system Tcl/Tk.)
+  • brew install python-tk@3.14
+    Match `python3 --version`, recreate .venv, then the Tk fallback can load.
+  • Headless: python -m sharp_local_batch --cli --folder /path/to/photos --recursive
+"""
+
+
+def main() -> None:
+    if len(sys.argv) >= 2 and sys.argv[1] == "--cli":
+        sys.argv.pop(1)
+        raise SystemExit(_cli_main())
+    try:
+        from sharp_local_batch.gui_qt import main as gui_main
+
+        gui_main()
+        return
+    except ImportError:
+        pass
+    try:
+        from sharp_local_batch.gui import main as gui_main
+
+        gui_main()
+    except ImportError as e:
+        err = str(e).lower()
+        if "_tkinter" in err or "tkinter" in err:
+            print(_GUI_HELP, file=sys.stderr)
+            raise SystemExit(1) from e
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/sharp_local_batch/__main__.py
+++ b/sharp_local_batch/__main__.py
@@ -6,6 +6,10 @@ import argparse
 import sys
 from pathlib import Path
 
+from sharp_local_batch.logging_config import ensure_stderr_info_logging
+
+ensure_stderr_info_logging()
+
 from sharp_local_batch.batch_runner import scan_jobs
 from sharp_local_batch.core import (
     PHOTOS_LIBRARY_MIRROR_HELP,

--- a/sharp_local_batch/batch_runner.py
+++ b/sharp_local_batch/batch_runner.py
@@ -1,0 +1,170 @@
+"""Job queue worker and optional filesystem watch (watchdog)."""
+
+from __future__ import annotations
+
+import queue
+import threading
+from pathlib import Path
+from typing import Callable, Optional
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+from sharp_local_batch.core import (
+    PlySidecarResult,
+    is_supported_image,
+    list_image_paths,
+    needs_ply_refresh,
+    process_image_to_sidecar_ply,
+    sidecar_ply_path,
+)
+
+
+def scan_jobs(
+    root: Path,
+    recursive: bool,
+    *,
+    force_all: bool,
+) -> list[Path]:
+    """Images under ``root`` that need work (or all images if ``force_all``)."""
+    paths = list_image_paths(root, recursive)
+    if force_all:
+        return paths
+    return [p for p in paths if needs_ply_refresh(p)]
+
+
+class DebouncedScheduler:
+    """Call ``on_ready(path)`` after ``delay_sec`` quiet period per path."""
+
+    def __init__(self, delay_sec: float, on_ready: Callable[[Path], None]) -> None:
+        self.delay_sec = delay_sec
+        self.on_ready = on_ready
+        self._timers: dict[str, threading.Timer] = {}
+        self._lock = threading.Lock()
+
+    def schedule(self, path: Path) -> None:
+        key = str(path.resolve())
+        with self._lock:
+            old = self._timers.pop(key, None)
+            if old is not None:
+                old.cancel()
+
+            def fire() -> None:
+                with self._lock:
+                    self._timers.pop(key, None)
+                self.on_ready(path)
+
+            t = threading.Timer(self.delay_sec, fire)
+            t.daemon = True
+            self._timers[key] = t
+            t.start()
+
+    def cancel_all(self) -> None:
+        with self._lock:
+            for t in self._timers.values():
+                t.cancel()
+            self._timers.clear()
+
+
+class _ImageWatchHandler(FileSystemEventHandler):
+    def __init__(self, scheduler: DebouncedScheduler) -> None:
+        self._scheduler = scheduler
+
+    def on_created(self, event: object) -> None:
+        self._handle(event)
+
+    def on_modified(self, event: object) -> None:
+        self._handle(event)
+
+    def _handle(self, event: object) -> None:
+        if getattr(event, "is_directory", False):
+            return
+        src = getattr(event, "src_path", None)
+        if not src:
+            return
+        p = Path(src)
+        if not is_supported_image(p):
+            return
+        if any(part.startswith(".") for part in p.parts):
+            return
+        self._scheduler.schedule(p)
+
+
+class WatchController:
+    """Watchdog observer; debounces and enqueues paths via ``enqueue``."""
+
+    def __init__(
+        self,
+        root: Path,
+        enqueue: Callable[[Path], None],
+        *,
+        debounce_sec: float = 0.6,
+        recursive: bool = True,
+    ) -> None:
+        self._root = root.resolve()
+        self._recursive = recursive
+        self._scheduler = DebouncedScheduler(debounce_sec, enqueue)
+        self._handler = _ImageWatchHandler(self._scheduler)
+        self._observer: Optional[Observer] = None
+
+    def start(self) -> None:
+        if self._observer is not None:
+            return
+        obs = Observer()
+        obs.schedule(self._handler, str(self._root), recursive=self._recursive)
+        obs.start()
+        self._observer = obs
+
+    def stop(self) -> None:
+        self._scheduler.cancel_all()
+        if self._observer is not None:
+            self._observer.stop()
+            self._observer.join(timeout=5.0)
+            self._observer = None
+
+
+def worker_loop(
+    job_q: "queue.Queue[Optional[Path]]",
+    stop_event: threading.Event,
+    *,
+    limit_splats: bool,
+    max_splats: Optional[int],
+    skip_up_to_date: bool,
+    on_result: Callable[[PlySidecarResult], None],
+) -> None:
+    """Drain ``job_q`` until ``None`` sentinel or ``stop_event``."""
+    while True:
+        if stop_event.is_set():
+            try:
+                while True:
+                    job_q.get_nowait()
+            except queue.Empty:
+                pass
+            break
+        try:
+            item = job_q.get(timeout=0.35)
+        except queue.Empty:
+            continue
+        if item is None:
+            break
+        if stop_event.is_set():
+            break
+        image_path = item.resolve()
+        if skip_up_to_date and not needs_ply_refresh(image_path):
+            on_result(
+                PlySidecarResult(
+                    ok=True,
+                    image_path=image_path,
+                    ply_path=sidecar_ply_path(image_path),
+                    message="Skipped (PLY up to date)",
+                    skipped=True,
+                )
+            )
+            continue
+        on_result(
+            process_image_to_sidecar_ply(
+                image_path,
+                limit_splats=limit_splats,
+                max_splats=max_splats,
+            )
+        )

--- a/sharp_local_batch/batch_runner.py
+++ b/sharp_local_batch/batch_runner.py
@@ -45,14 +45,15 @@ def scan_jobs(
     if mirror_output_root is None:
         return [p for p in paths if needs_ply_refresh(p)], total
     out_r = mirror_output_root.resolve()
-    return (
-        [
-            p
-            for p in paths
-            if needs_ply_refresh(p, mirrored_ply_path(p, root_r, out_r))
-        ],
-        total,
-    )
+
+    def _needs_work(p: Path) -> bool:
+        try:
+            target = mirrored_ply_path(p, root_r, out_r)
+        except ValueError:
+            return True
+        return needs_ply_refresh(p, target)
+
+    return [p for p in paths if _needs_work(p)], total
 
 
 class DebouncedScheduler:
@@ -98,10 +99,13 @@ class _ImageWatchHandler(FileSystemEventHandler):
     def on_modified(self, event: object) -> None:
         self._handle(event)
 
-    def _handle(self, event: object) -> None:
+    def on_moved(self, event: object) -> None:
+        self._handle(event, path_attr="dest_path")
+
+    def _handle(self, event: object, *, path_attr: str = "src_path") -> None:
         if getattr(event, "is_directory", False):
             return
-        src = getattr(event, "src_path", None)
+        src = getattr(event, path_attr, None)
         if not src:
             return
         p = Path(src)

--- a/sharp_local_batch/batch_runner.py
+++ b/sharp_local_batch/batch_runner.py
@@ -29,21 +29,30 @@ def scan_jobs(
     *,
     force_all: bool,
     mirror_output_root: Optional[Path] = None,
-) -> list[Path]:
-    """Images under ``root`` that need work (or all images if ``force_all``)."""
+) -> tuple[list[Path], int]:
+    """Images under ``root`` that need work (or all images if ``force_all``).
+
+    Returns ``(jobs, total_supported_images)`` where *total_supported_images* is the
+    count of supported files found before the PLY-freshness filter — useful to tell
+    “nothing on disk” from “everything already processed”.
+    """
     scan_root = effective_batch_scan_root(root)
     paths = list_image_paths(scan_root, recursive)
+    total = len(paths)
     if force_all:
-        return paths
+        return paths, total
     root_r = root.resolve()
     if mirror_output_root is None:
-        return [p for p in paths if needs_ply_refresh(p)]
+        return [p for p in paths if needs_ply_refresh(p)], total
     out_r = mirror_output_root.resolve()
-    return [
-        p
-        for p in paths
-        if needs_ply_refresh(p, mirrored_ply_path(p, root_r, out_r))
-    ]
+    return (
+        [
+            p
+            for p in paths
+            if needs_ply_refresh(p, mirrored_ply_path(p, root_r, out_r))
+        ],
+        total,
+    )
 
 
 class DebouncedScheduler:

--- a/sharp_local_batch/batch_runner.py
+++ b/sharp_local_batch/batch_runner.py
@@ -12,9 +12,12 @@ from watchdog.observers import Observer
 
 from sharp_local_batch.core import (
     PlySidecarResult,
+    effective_batch_scan_root,
     is_supported_image,
     list_image_paths,
+    mirrored_ply_path,
     needs_ply_refresh,
+    output_ply_path_for_job,
     process_image_to_sidecar_ply,
     sidecar_ply_path,
 )
@@ -25,12 +28,22 @@ def scan_jobs(
     recursive: bool,
     *,
     force_all: bool,
+    mirror_output_root: Optional[Path] = None,
 ) -> list[Path]:
     """Images under ``root`` that need work (or all images if ``force_all``)."""
-    paths = list_image_paths(root, recursive)
+    scan_root = effective_batch_scan_root(root)
+    paths = list_image_paths(scan_root, recursive)
     if force_all:
         return paths
-    return [p for p in paths if needs_ply_refresh(p)]
+    root_r = root.resolve()
+    if mirror_output_root is None:
+        return [p for p in paths if needs_ply_refresh(p)]
+    out_r = mirror_output_root.resolve()
+    return [
+        p
+        for p in paths
+        if needs_ply_refresh(p, mirrored_ply_path(p, root_r, out_r))
+    ]
 
 
 class DebouncedScheduler:
@@ -111,7 +124,8 @@ class WatchController:
         if self._observer is not None:
             return
         obs = Observer()
-        obs.schedule(self._handler, str(self._root), recursive=self._recursive)
+        watch_path = effective_batch_scan_root(self._root)
+        obs.schedule(self._handler, str(watch_path), recursive=self._recursive)
         obs.start()
         self._observer = obs
 
@@ -130,6 +144,8 @@ def worker_loop(
     limit_splats: bool,
     max_splats: Optional[int],
     skip_up_to_date: bool,
+    mirror_output_root: Optional[Path],
+    mirror_input_root: Optional[Path],
     on_result: Callable[[PlySidecarResult], None],
 ) -> None:
     """Drain ``job_q`` until ``None`` sentinel or ``stop_event``."""
@@ -150,12 +166,28 @@ def worker_loop(
         if stop_event.is_set():
             break
         image_path = item.resolve()
-        if skip_up_to_date and not needs_ply_refresh(image_path):
+        try:
+            ply_target = output_ply_path_for_job(
+                image_path,
+                mirror_output_root=mirror_output_root,
+                mirror_input_root=mirror_input_root,
+            )
+        except ValueError as e:
+            on_result(
+                PlySidecarResult(
+                    ok=False,
+                    image_path=image_path,
+                    ply_path=sidecar_ply_path(image_path),
+                    message=str(e),
+                )
+            )
+            continue
+        if skip_up_to_date and not needs_ply_refresh(image_path, ply_target):
             on_result(
                 PlySidecarResult(
                     ok=True,
                     image_path=image_path,
-                    ply_path=sidecar_ply_path(image_path),
+                    ply_path=ply_target,
                     message="Skipped (PLY up to date)",
                     skipped=True,
                 )
@@ -166,5 +198,6 @@ def worker_loop(
                 image_path,
                 limit_splats=limit_splats,
                 max_splats=max_splats,
+                ply_output_path=ply_target,
             )
         )

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -25,12 +25,7 @@ ML_SHARP_SRC = REPO_ROOT / "ml-sharp" / "src"
 if ML_SHARP_SRC.is_dir():
     sys.path.insert(0, str(ML_SHARP_SRC))
 
-LOGGER = logging.getLogger("sharp_local_batch.core")
-if not LOGGER.handlers:
-    _h = logging.StreamHandler()
-    _h.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
-    LOGGER.addHandler(_h)
-    LOGGER.setLevel(logging.INFO)
+LOGGER = logging.getLogger(__name__)
 
 if not ML_SHARP_SRC.is_dir():
     LOGGER.warning(

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import logging
 import shutil
 import subprocess
@@ -149,11 +150,12 @@ def decimate_ply_splat_transform(
         return False
 
 
-def supported_image_suffixes() -> set[str]:
+@functools.lru_cache(maxsize=1)
+def supported_image_suffixes() -> frozenset[str]:
     ensure_sharp_imports()
     from sharp.utils import io as sharp_io
 
-    return {ext.lower() for ext in sharp_io.get_supported_image_extensions()}
+    return frozenset(ext.lower() for ext in sharp_io.get_supported_image_extensions())
 
 
 def is_supported_image(path: Path) -> bool:

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import os
 import shutil
 import subprocess
 import sys
@@ -166,9 +167,30 @@ def list_image_paths(root: Path, recursive: bool) -> list[Path]:
     allowed = supported_image_suffixes()
     out: list[Path] = []
     if recursive:
-        for p in root.rglob("*"):
-            if p.is_file() and p.suffix.lower() in allowed and not _path_is_skipped(p):
-                out.append(p)
+        try:
+            root_r = root.resolve()
+        except OSError:
+            root_r = root
+        if not root_r.is_dir():
+            return []
+        for dirpath, dirnames, filenames in os.walk(
+            root_r, topdown=True, followlinks=False
+        ):
+            dirnames[:] = [d for d in dirnames if not d.startswith(".")]
+            base = Path(dirpath)
+            for name in filenames:
+                if name.startswith("."):
+                    continue
+                p = base / name
+                try:
+                    if (
+                        p.is_file()
+                        and p.suffix.lower() in allowed
+                        and not _path_is_skipped(p)
+                    ):
+                        out.append(p)
+                except OSError:
+                    continue
     else:
         for p in root.iterdir():
             if p.is_file() and p.suffix.lower() in allowed and not _path_is_skipped(p):

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -1,0 +1,300 @@
+"""Shared SHARP inference, PLY sidecar output, and splat-transform decimation."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import sys
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+
+def _bundle_root() -> Path:
+    """Repo root in dev; PyInstaller extract dir when frozen (see packaging/sharp_batch.spec)."""
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+        return Path(sys._MEIPASS)
+    return Path(__file__).resolve().parent.parent
+
+
+REPO_ROOT = _bundle_root()
+ML_SHARP_SRC = REPO_ROOT / "ml-sharp" / "src"
+
+if ML_SHARP_SRC.is_dir():
+    sys.path.insert(0, str(ML_SHARP_SRC))
+
+LOGGER = logging.getLogger("sharp_local_batch.core")
+if not LOGGER.handlers:
+    _h = logging.StreamHandler()
+    _h.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
+    LOGGER.addHandler(_h)
+    LOGGER.setLevel(logging.INFO)
+
+if not ML_SHARP_SRC.is_dir():
+    LOGGER.warning(
+        "ml-sharp not found at %s — run: git submodule update --init ml-sharp",
+        ML_SHARP_SRC.parent,
+    )
+
+PREDICT_LOCK = threading.Lock()
+_predictor: Any = None
+_device: Optional[str] = None
+
+
+def ensure_sharp_imports() -> None:
+    if not ML_SHARP_SRC.is_dir():
+        raise RuntimeError(
+            f"ml-sharp missing at {ML_SHARP_SRC}. From the repo root run: "
+            "git submodule update --init ml-sharp or ./bootstrap.sh (see README)."
+        )
+    import sharp  # noqa: F401
+
+
+def predictor_loaded() -> bool:
+    return _predictor is not None
+
+
+def inference_device() -> Optional[str]:
+    return _device
+
+
+def get_predictor() -> tuple[Any, str]:
+    global _predictor, _device
+    ensure_sharp_imports()
+    if _predictor is not None and _device is not None:
+        return _predictor, _device
+
+    import torch
+    from sharp.cli.predict import DEFAULT_MODEL_URL
+    from sharp.models import PredictorParams, create_predictor
+
+    if torch.cuda.is_available():
+        _device = "cuda"
+    elif torch.mps.is_available():
+        _device = "mps"
+    else:
+        _device = "cpu"
+
+    LOGGER.info("Loading SHARP checkpoint (first run may download weights) on %s", _device)
+    state_dict = torch.hub.load_state_dict_from_url(DEFAULT_MODEL_URL, progress=True)
+    predictor = create_predictor(PredictorParams())
+    predictor.load_state_dict(state_dict)
+    predictor.eval()
+    predictor.to(_device)
+    _predictor = predictor
+    return _predictor, _device
+
+
+def count_ply_vertices(ply_path: Path) -> int:
+    """Vertex count from the PLY ASCII header only (no full file decode)."""
+    vertex_count: Optional[int] = None
+    with ply_path.open("r", encoding="ascii", errors="replace") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line:
+                continue
+            if line == "end_header":
+                break
+            parts = line.split()
+            if len(parts) == 3 and parts[0] == "element" and parts[1] == "vertex":
+                try:
+                    vertex_count = int(parts[2])
+                except ValueError:
+                    pass
+    if vertex_count is None:
+        raise ValueError(
+            f"PLY header missing valid 'element vertex N' before end_header: {ply_path}"
+        )
+    return vertex_count
+
+
+def decimate_ply_splat_transform(
+    ply_path: Path, target_count: int, timeout_sec: int = 7200
+) -> bool:
+    """Decimate PLY in place via PlayCanvas splat-transform CLI."""
+    exe = shutil.which("splat-transform")
+    if not exe:
+        LOGGER.warning(
+            "splat-transform not on PATH; install: npm install -g @playcanvas/splat-transform"
+        )
+        return False
+    tmp_out = ply_path.with_name("_splat_decimated_tmp.ply")
+    try:
+        tmp_out.unlink(missing_ok=True)
+        cmd = [exe, str(ply_path), "--decimate", str(target_count), str(tmp_out)]
+        r = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout_sec,
+        )
+        if r.returncode != 0:
+            err = (r.stderr or r.stdout or "").strip()
+            LOGGER.warning(
+                "splat-transform failed (exit %s): %s",
+                r.returncode,
+                err[:2000] if err else "(no output)",
+            )
+            tmp_out.unlink(missing_ok=True)
+            return False
+        if not tmp_out.is_file():
+            LOGGER.warning("splat-transform produced no output file")
+            return False
+        tmp_out.replace(ply_path)
+        return True
+    except subprocess.TimeoutExpired:
+        LOGGER.warning("splat-transform timed out after %s s", timeout_sec)
+        tmp_out.unlink(missing_ok=True)
+        return False
+    except OSError as e:
+        LOGGER.warning("splat-transform output handling failed: %s", e)
+        tmp_out.unlink(missing_ok=True)
+        return False
+
+
+def supported_image_suffixes() -> set[str]:
+    ensure_sharp_imports()
+    from sharp.utils import io as sharp_io
+
+    return {ext.lower() for ext in sharp_io.get_supported_image_extensions()}
+
+
+def is_supported_image(path: Path) -> bool:
+    return path.is_file() and path.suffix.lower() in supported_image_suffixes()
+
+
+def list_image_paths(root: Path, recursive: bool) -> list[Path]:
+    allowed = supported_image_suffixes()
+    out: list[Path] = []
+    if recursive:
+        for p in root.rglob("*"):
+            if p.is_file() and p.suffix.lower() in allowed and not _path_is_skipped(p):
+                out.append(p)
+    else:
+        for p in root.iterdir():
+            if p.is_file() and p.suffix.lower() in allowed and not _path_is_skipped(p):
+                out.append(p)
+    out.sort(key=lambda x: str(x).lower())
+    return out
+
+
+def _path_is_skipped(path: Path) -> bool:
+    return any(part.startswith(".") for part in path.parts)
+
+
+def sidecar_ply_path(image_path: Path) -> Path:
+    return image_path.with_suffix(".ply")
+
+
+def needs_ply_refresh(image_path: Path) -> bool:
+    ply = sidecar_ply_path(image_path)
+    if not ply.is_file():
+        return True
+    try:
+        return image_path.stat().st_mtime > ply.stat().st_mtime
+    except OSError:
+        return True
+
+
+@dataclass
+class PlySidecarResult:
+    ok: bool
+    image_path: Path
+    ply_path: Path
+    message: str
+    splat_count: Optional[int] = None
+    splat_count_full: Optional[int] = None
+    limit_applied: bool = False
+    decimate_error: Optional[str] = None
+    skipped: bool = False
+
+
+def process_image_to_sidecar_ply(
+    image_path: Path,
+    *,
+    limit_splats: bool = False,
+    max_splats: Optional[int] = None,
+) -> PlySidecarResult:
+    """Run SHARP on ``image_path`` and write ``<stem>.ply`` beside it; optional decimate."""
+    image_path = image_path.resolve()
+    ply_path = sidecar_ply_path(image_path)
+
+    if not is_supported_image(image_path):
+        return PlySidecarResult(
+            ok=False,
+            image_path=image_path,
+            ply_path=ply_path,
+            message=f"Unsupported or missing image: {image_path}",
+        )
+
+    if limit_splats and max_splats is not None:
+        if max_splats < 1:
+            return PlySidecarResult(
+                ok=False,
+                image_path=image_path,
+                ply_path=ply_path,
+                message="max_splats must be at least 1",
+            )
+
+    ensure_sharp_imports()
+    from sharp.cli.predict import predict_image
+    from sharp.utils import io as sharp_io
+    from sharp.utils.gaussians import save_ply
+
+    import torch
+
+    try:
+        ply_path.parent.mkdir(parents=True, exist_ok=True)
+        with PREDICT_LOCK:
+            predictor, device_str = get_predictor()
+            image, _, f_px = sharp_io.load_rgb(image_path)
+            height, width = int(image.shape[0]), int(image.shape[1])
+            device = torch.device(device_str)
+            gaussians = predict_image(predictor, image, f_px, device)
+            save_ply(gaussians, f_px, (height, width), ply_path)
+    except Exception as e:
+        LOGGER.exception("Inference failed for %s", image_path)
+        try:
+            ply_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return PlySidecarResult(
+            ok=False,
+            image_path=image_path,
+            ply_path=ply_path,
+            message=str(e),
+        )
+
+    splat_count_full = count_ply_vertices(ply_path)
+    splat_count = splat_count_full
+    limit_applied = False
+    decimate_error: Optional[str] = None
+
+    if limit_splats and max_splats is not None and splat_count_full > max_splats:
+        if decimate_ply_splat_transform(ply_path, max_splats):
+            splat_count = count_ply_vertices(ply_path)
+            limit_applied = splat_count < splat_count_full
+        else:
+            decimate_error = (
+                "Decimation failed or splat-transform missing; "
+                "install: npm install -g @playcanvas/splat-transform"
+            )
+
+    msg = f"OK — {splat_count:,} splats"
+    if limit_applied and splat_count_full > splat_count:
+        msg += f" (from {splat_count_full:,})"
+    if decimate_error:
+        msg += f"; {decimate_error}"
+
+    return PlySidecarResult(
+        ok=True,
+        image_path=image_path,
+        ply_path=ply_path,
+        message=msg,
+        splat_count=splat_count,
+        splat_count_full=splat_count_full,
+        limit_applied=limit_applied,
+        decimate_error=decimate_error,
+    )

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -271,11 +271,23 @@ def mirrored_ply_path(image_path: Path, input_root: Path, output_root: Path) -> 
     """
     img = image_path.resolve()
     out_r = output_root.resolve()
+    input_r = input_root.resolve()
     try:
-        home_r = Path.home().resolve()
-        rel = img.relative_to(home_r)
-    except (ValueError, OSError):
-        rel = img.relative_to(input_root.resolve())
+        home_r: Optional[Path] = Path.home().resolve()
+    except (OSError, RuntimeError):
+        home_r = None
+    if home_r is not None:
+        try:
+            return (out_r / img.relative_to(home_r)).with_suffix(".ply")
+        except ValueError:
+            pass
+    try:
+        rel = img.relative_to(input_r)
+    except ValueError as exc:
+        raise ValueError(
+            f"Cannot mirror PLY path for {img}: not under "
+            f"home ({home_r}) or input root {input_r}"
+        ) from exc
     return (out_r / rel).with_suffix(".ply")
 
 

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -173,8 +173,10 @@ def list_image_paths(root: Path, recursive: bool) -> list[Path]:
             root_r = root
         if not root_r.is_dir():
             return []
+        # followlinks=True matches pathlib.rglob: descend symlinked dirs (Photos may use
+        # them). Rare symlink cycles are acceptable for typical library trees.
         for dirpath, dirnames, filenames in os.walk(
-            root_r, topdown=True, followlinks=False
+            root_r, topdown=True, followlinks=True
         ):
             dirnames[:] = [d for d in dirnames if not d.startswith(".")]
             base = Path(dirpath)

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -188,8 +188,86 @@ def sidecar_ply_path(image_path: Path) -> Path:
     return image_path.with_suffix(".ply")
 
 
-def needs_ply_refresh(image_path: Path) -> bool:
-    ply = sidecar_ply_path(image_path)
+def default_macos_photos_library_path() -> Path:
+    """Default Apple Photos library bundle path (macOS)."""
+    return Path.home() / "Pictures" / "Photos Library.photoslibrary"
+
+
+def is_photos_library_bundle(path: Path) -> bool:
+    """True if ``path`` is a ``.photoslibrary`` package (do not write PLY inside)."""
+    try:
+        p = path.resolve()
+        return p.is_dir() and p.suffix.lower() == ".photoslibrary"
+    except OSError:
+        return False
+
+
+def effective_batch_scan_root(library_or_folder: Path) -> Path:
+    """Directory to enumerate for images.
+
+    Apple Photos stores downloadable originals under ``originals/`` (and older
+    libraries may use ``Masters/``) inside the ``.photoslibrary`` bundle — same
+    as ``backend/api.py`` (``PHOTO_DIRS`` / iCloud discovery). Scanning the
+    bundle root alone often misses those files.
+    """
+    try:
+        p = library_or_folder.resolve()
+    except OSError:
+        return library_or_folder
+    if not is_photos_library_bundle(p):
+        return p
+    originals = p / "originals"
+    if originals.is_dir():
+        return originals
+    masters = p / "Masters"
+    if masters.is_dir():
+        return masters
+    return p
+
+
+PHOTOS_LIBRARY_MIRROR_HELP = (
+    "A Photos Library.photoslibrary bundle cannot store PLY files next to originals. "
+    "Enable mirror output and choose a target folder for mirror outside that package."
+)
+
+
+def mirrored_ply_path(image_path: Path, input_root: Path, output_root: Path) -> Path:
+    """PLY path under ``output_root`` mirroring a relative path under the home folder.
+
+    When the image resolves under the user's home directory (e.g.
+    ``~/Pictures/Photos Library.photoslibrary/originals/…``), the mirror
+    layout is ``<output_root>/Pictures/Photos Library.photoslibrary/originals/…``
+    so the tree is unambiguous and not only ``originals/…``. Otherwise the
+    path is relative to ``input_root`` (unchanged behavior for paths outside
+    home, e.g. external volumes).
+    """
+    img = image_path.resolve()
+    out_r = output_root.resolve()
+    try:
+        home_r = Path.home().resolve()
+        rel = img.relative_to(home_r)
+    except (ValueError, OSError):
+        rel = img.relative_to(input_root.resolve())
+    return (out_r / rel).with_suffix(".ply")
+
+
+def output_ply_path_for_job(
+    image_path: Path,
+    *,
+    mirror_output_root: Optional[Path],
+    mirror_input_root: Optional[Path],
+) -> Path:
+    """Sidecar next to the image, or mirrored under ``mirror_output_root`` when set."""
+    img = image_path.resolve()
+    if mirror_output_root is None:
+        return sidecar_ply_path(img)
+    if mirror_input_root is None:
+        raise ValueError("mirror_input_root is required when mirror_output_root is set")
+    return mirrored_ply_path(img, mirror_input_root, mirror_output_root)
+
+
+def needs_ply_refresh(image_path: Path, ply_path: Optional[Path] = None) -> bool:
+    ply = sidecar_ply_path(image_path) if ply_path is None else ply_path
     if not ply.is_file():
         return True
     try:
@@ -216,10 +294,11 @@ def process_image_to_sidecar_ply(
     *,
     limit_splats: bool = False,
     max_splats: Optional[int] = None,
+    ply_output_path: Optional[Path] = None,
 ) -> PlySidecarResult:
-    """Run SHARP on ``image_path`` and write ``<stem>.ply`` beside it; optional decimate."""
+    """Run SHARP on ``image_path`` and write PLY beside it or at ``ply_output_path``; optional decimate."""
     image_path = image_path.resolve()
-    ply_path = sidecar_ply_path(image_path)
+    ply_path = sidecar_ply_path(image_path) if ply_output_path is None else ply_output_path.resolve()
 
     if not is_supported_image(image_path):
         return PlySidecarResult(

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 from dataclasses import dataclass
 from pathlib import Path
@@ -117,7 +118,13 @@ def decimate_ply_splat_transform(
             "splat-transform not on PATH; install: npm install -g @playcanvas/splat-transform"
         )
         return False
-    tmp_out = ply_path.with_name("_splat_decimated_tmp.ply")
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        prefix=f"._splat_decimated_{ply_path.stem}_",
+        suffix=".ply",
+        dir=str(ply_path.parent),
+    )
+    os.close(tmp_fd)
+    tmp_out = Path(tmp_name)
     try:
         tmp_out.unlink(missing_ok=True)
         cmd = [exe, str(ply_path), "--decimate", str(target_count), str(tmp_out)]

--- a/sharp_local_batch/gui.py
+++ b/sharp_local_batch/gui.py
@@ -80,12 +80,21 @@ class SharpBatchGui:
             ttk.Checkbutton(
                 row_pl,
                 text=(
-                    "Use Apple Photos library bundle (Photos Library.photoslibrary; "
-                    "mirror required)"
+                    "Use system Photos library as source folder "
+                    "(Photos Library.photoslibrary; mirror required)"
                 ),
                 variable=self._photos_lib_var,
                 command=self._on_macos_photos_library_toggle,
             ).pack(anchor=tk.W)
+            ttk.Label(
+                row_pl,
+                text=(
+                    "Fills the Folder field above — one source only, not an extra path. "
+                    "Uncheck to browse your own folder."
+                ),
+                wraplength=520,
+                foreground="#666",
+            ).pack(anchor=tk.W, padx=(22, 0), pady=(0, 2))
 
         row1b = ttk.Frame(root_f)
         row1b.pack(fill=tk.X, **pad)

--- a/sharp_local_batch/gui.py
+++ b/sharp_local_batch/gui.py
@@ -1,0 +1,339 @@
+"""Tkinter UI for folder batch + optional filesystem watch."""
+
+from __future__ import annotations
+
+import queue
+import threading
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox, ttk
+
+from sharp_local_batch.batch_runner import WatchController, scan_jobs
+from sharp_local_batch.core import (
+    PlySidecarResult,
+    needs_ply_refresh,
+    process_image_to_sidecar_ply,
+    sidecar_ply_path,
+)
+
+
+class SharpBatchGui:
+    def __init__(self) -> None:
+        self.root = tk.Tk()
+        self.root.title("sharp_local_batch")
+        self.root.minsize(520, 420)
+
+        self._folder_var = tk.StringVar(value="")
+        self._recursive_var = tk.BooleanVar(value=True)
+        self._force_all_var = tk.BooleanVar(value=False)
+        self._limit_var = tk.BooleanVar(value=False)
+        self._max_splats_var = tk.StringVar(value="500000")
+        self._skip_up_to_date_var = tk.BooleanVar(value=True)
+        self._watch_var = tk.BooleanVar(value=False)
+
+        self._job_q: queue.Queue[Path] = queue.Queue()
+        self._quit_app = threading.Event()
+        self._opts_lock = threading.Lock()
+        self._snap_lim = False
+        self._snap_max: int | None = None
+        self._snap_skip = True
+        self._scan_running = False
+        self._batch_total = 0
+        self._batch_done = 0
+        self._watch: WatchController | None = None
+        self._processed_session = 0
+
+        self._build_ui()
+
+        self._worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self._worker.start()
+
+        self.root.protocol("WM_DELETE_WINDOW", self._on_close)
+
+    def _build_ui(self) -> None:
+        pad = {"padx": 10, "pady": 4}
+        root_f = ttk.Frame(self.root, padding=10)
+        root_f.pack(fill=tk.BOTH, expand=True)
+
+        row1 = ttk.Frame(root_f)
+        row1.pack(fill=tk.X, **pad)
+        ttk.Label(row1, text="Folder").pack(side=tk.LEFT)
+        ttk.Entry(row1, textvariable=self._folder_var, width=48).pack(
+            side=tk.LEFT, fill=tk.X, expand=True, padx=(8, 4)
+        )
+        ttk.Button(row1, text="Browse…", command=self._browse).pack(side=tk.LEFT)
+
+        row2 = ttk.Frame(root_f)
+        row2.pack(fill=tk.X, **pad)
+        ttk.Checkbutton(row2, text="Include subfolders", variable=self._recursive_var).pack(
+            side=tk.LEFT
+        )
+        ttk.Checkbutton(
+            row2,
+            text="Reprocess all (ignore PLY freshness)",
+            variable=self._force_all_var,
+        ).pack(side=tk.LEFT, padx=(16, 0))
+
+        row3 = ttk.Frame(root_f)
+        row3.pack(fill=tk.X, **pad)
+        ttk.Checkbutton(row3, text="Limit splat count", variable=self._limit_var).pack(
+            side=tk.LEFT
+        )
+        ttk.Label(row3, text="Max splats").pack(side=tk.LEFT, padx=(8, 4))
+        self._max_entry = ttk.Entry(row3, textvariable=self._max_splats_var, width=12)
+        self._max_entry.pack(side=tk.LEFT)
+        ttk.Checkbutton(
+            row3,
+            text="Skip up-to-date PLY",
+            variable=self._skip_up_to_date_var,
+        ).pack(side=tk.LEFT, padx=(16, 0))
+
+        self._limit_var.trace_add("write", lambda *_: self._sync_limit_widgets())
+        self._sync_limit_widgets()
+
+        row4 = ttk.Frame(root_f)
+        row4.pack(fill=tk.X, **pad)
+        ttk.Button(row4, text="Scan & queue jobs", command=self._on_scan).pack(
+            side=tk.LEFT
+        )
+        ttk.Button(row4, text="Stop", command=self._on_stop).pack(side=tk.LEFT, padx=(8, 0))
+        self._watch_cb = ttk.Checkbutton(
+            row4,
+            text="Watch folder (new / changed images)",
+            variable=self._watch_var,
+            command=self._on_watch_toggle,
+        )
+        self._watch_cb.pack(side=tk.LEFT, padx=(16, 0))
+
+        row5 = ttk.Frame(root_f)
+        row5.pack(fill=tk.X, **pad)
+        ttk.Label(row5, text="Batch progress").pack(anchor=tk.W)
+        self._progress = ttk.Progressbar(row5, mode="determinate", maximum=100, value=0)
+        self._progress.pack(fill=tk.X, pady=(4, 0))
+        self._progress_label = ttk.Label(row5, text="—")
+        self._progress_label.pack(anchor=tk.W, pady=(2, 0))
+
+        log_f = ttk.LabelFrame(root_f, text="Log", padding=6)
+        log_f.pack(fill=tk.BOTH, expand=True, **pad)
+        self._log = tk.Text(log_f, height=14, wrap=tk.WORD, font=("Courier", 11))
+        scroll = ttk.Scrollbar(log_f, command=self._log.yview)
+        self._log.configure(yscrollcommand=scroll.set)
+        self._log.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        scroll.pack(side=tk.RIGHT, fill=tk.Y)
+
+        hint = (
+            "Writes <name>.ply next to each image. "
+            "Optional cap uses splat-transform (npm i -g @playcanvas/splat-transform)."
+        )
+        ttk.Label(root_f, text=hint, wraplength=500, foreground="#666").pack(
+            fill=tk.X, **pad
+        )
+
+    def _sync_limit_widgets(self) -> None:
+        on = self._limit_var.get()
+        self._max_entry.configure(state=tk.NORMAL if on else "disabled")
+
+    def _browse(self) -> None:
+        d = filedialog.askdirectory()
+        if d:
+            self._folder_var.set(d)
+
+    def _snapshot_opts(self) -> None:
+        lim = self._limit_var.get()
+        mx = self._parse_max_splats() if lim else None
+        if lim and mx is None:
+            mx = 500_000
+        skip = self._skip_up_to_date_var.get()
+        with self._opts_lock:
+            self._snap_lim = bool(lim)
+            self._snap_max = mx if lim else None
+            self._snap_skip = skip
+
+    def _parse_max_splats(self) -> int | None:
+        if not self._limit_var.get():
+            return None
+        raw = self._max_splats_var.get().strip()
+        try:
+            n = int(raw, 10)
+        except ValueError:
+            return None
+        if n < 1:
+            return None
+        return min(n, 10_000_000)
+
+    def _limit_options(self) -> tuple[bool, int | None]:
+        lim = self._limit_var.get()
+        m = self._parse_max_splats()
+        if lim and m is None:
+            messagebox.showerror(
+                "Invalid max splats",
+                "Enter a positive integer for max splats when limit is enabled.",
+            )
+            return False, None
+        return lim, m if lim else None
+
+    def _on_scan(self) -> None:
+        ok, max_s = self._limit_options()
+        if not ok:
+            return
+        raw = self._folder_var.get().strip()
+        if not raw:
+            messagebox.showwarning("Folder", "Choose a folder first.")
+            return
+        root = Path(raw).expanduser()
+        if not root.is_dir():
+            messagebox.showerror("Folder", f"Not a directory: {root}")
+            return
+
+        jobs = scan_jobs(
+            root,
+            self._recursive_var.get(),
+            force_all=self._force_all_var.get(),
+        )
+        if not jobs:
+            messagebox.showinfo("Scan", "No images need processing (PLY already fresh).")
+            return
+
+        self._snapshot_opts()
+        self._scan_running = True
+        self._batch_total = len(jobs)
+        self._batch_done = 0
+        self._progress.configure(maximum=self._batch_total, value=0, mode="determinate")
+        self._progress_label.config(text=f"Queued {len(jobs)} job(s)…")
+        self._log_line(f"--- Scan: {len(jobs)} job(s) ---")
+
+        for p in jobs:
+            self._job_q.put(p)
+
+    def _on_stop(self) -> None:
+        try:
+            while True:
+                self._job_q.get_nowait()
+        except queue.Empty:
+            pass
+        self._scan_running = False
+        self._batch_total = 0
+        self._batch_done = 0
+        self._progress.configure(value=0)
+        self._progress_label.config(text="Stopped")
+        self._log_line("--- Stop: queue cleared ---")
+
+    def _on_watch_toggle(self) -> None:
+        if self._watch_var.get():
+            self._start_watch()
+        else:
+            self._stop_watch()
+
+    def _start_watch(self) -> None:
+        ok, _mx = self._limit_options()
+        if not ok:
+            self._watch_var.set(False)
+            return
+        raw = self._folder_var.get().strip()
+        if not raw:
+            messagebox.showwarning("Watch", "Choose a folder first.")
+            self._watch_var.set(False)
+            return
+        root = Path(raw).expanduser()
+        if not root.is_dir():
+            messagebox.showerror("Watch", f"Not a directory: {root}")
+            self._watch_var.set(False)
+            return
+
+        if self._watch is not None:
+            return
+
+        self._snapshot_opts()
+
+        def enqueue(p: Path) -> None:
+            path = p.resolve()
+
+            def push() -> None:
+                self._snapshot_opts()
+                self._job_q.put(path)
+
+            self.root.after(0, push)
+
+        self._watch = WatchController(
+            root,
+            enqueue,
+            debounce_sec=0.6,
+            recursive=self._recursive_var.get(),
+        )
+        self._watch.start()
+        self._log_line(f"--- Watch started: {root} ---")
+
+    def _stop_watch(self) -> None:
+        if self._watch is not None:
+            self._watch.stop()
+            self._watch = None
+            self._log_line("--- Watch stopped ---")
+
+    def _worker_loop(self) -> None:
+        while not self._quit_app.is_set():
+            try:
+                item = self._job_q.get(timeout=0.35)
+            except queue.Empty:
+                continue
+            p = item
+            with self._opts_lock:
+                lim = self._snap_lim
+                max_s = self._snap_max
+                skip = self._snap_skip
+
+            if skip and not needs_ply_refresh(p):
+                r = PlySidecarResult(
+                    ok=True,
+                    image_path=p,
+                    ply_path=sidecar_ply_path(p),
+                    message="Skipped (PLY up to date)",
+                    skipped=True,
+                )
+            else:
+                r = process_image_to_sidecar_ply(
+                    p,
+                    limit_splats=lim,
+                    max_splats=max_s if lim else None,
+                )
+
+            self.root.after(0, lambda res=r: self._on_job_done(res))
+
+    def _on_job_done(self, r: PlySidecarResult) -> None:
+        if r.skipped:
+            self._log_line(f"[skip] {r.image_path.name} — {r.message}")
+        elif r.ok:
+            self._processed_session += 1
+            self._log_line(f"[ok] {r.image_path.name} — {r.message}")
+        else:
+            self._log_line(f"[err] {r.image_path.name} — {r.message}")
+
+        if self._batch_total > 0:
+            self._batch_done += 1
+            self._progress["value"] = self._batch_done
+            self._progress_label.config(
+                text=f"{self._batch_done} / {self._batch_total} files"
+            )
+            if self._batch_done >= self._batch_total:
+                self._batch_total = 0
+                self._batch_done = 0
+                self._scan_running = False
+                self._progress.configure(value=0, maximum=100)
+                self._progress_label.config(
+                    text=f"Batch done · session processed: {self._processed_session}"
+                )
+
+    def _log_line(self, text: str) -> None:
+        self._log.insert(tk.END, text + "\n")
+        self._log.see(tk.END)
+
+    def _on_close(self) -> None:
+        self._stop_watch()
+        self._quit_app.set()
+        self.root.destroy()
+
+    def run(self) -> None:
+        self.root.mainloop()
+
+
+def main() -> None:
+    SharpBatchGui().run()

--- a/sharp_local_batch/gui.py
+++ b/sharp_local_batch/gui.py
@@ -130,6 +130,7 @@ class SharpBatchGui:
             row2,
             text="Reprocess all (ignore PLY freshness)",
             variable=self._force_all_var,
+            command=self._sync_force_skip_widgets,
         ).pack(side=tk.LEFT, padx=(16, 0))
 
         row3 = ttk.Frame(root_f)
@@ -140,14 +141,16 @@ class SharpBatchGui:
         ttk.Label(row3, text="Max splats").pack(side=tk.LEFT, padx=(8, 4))
         self._max_entry = ttk.Entry(row3, textvariable=self._max_splats_var, width=12)
         self._max_entry.pack(side=tk.LEFT)
-        ttk.Checkbutton(
+        self._skip_cb = ttk.Checkbutton(
             row3,
             text="Skip up-to-date PLY",
             variable=self._skip_up_to_date_var,
-        ).pack(side=tk.LEFT, padx=(16, 0))
+        )
+        self._skip_cb.pack(side=tk.LEFT, padx=(16, 0))
 
         self._limit_var.trace_add("write", lambda *_: self._sync_limit_widgets())
         self._sync_limit_widgets()
+        self._sync_force_skip_widgets()
 
         row4 = ttk.Frame(root_f)
         row4.pack(fill=tk.X, **pad)
@@ -192,6 +195,13 @@ class SharpBatchGui:
         on = self._limit_var.get()
         self._max_entry.configure(state=tk.NORMAL if on else "disabled")
 
+    def _sync_force_skip_widgets(self) -> None:
+        if self._force_all_var.get():
+            self._skip_up_to_date_var.set(False)
+            self._skip_cb.state(["disabled"])
+        else:
+            self._skip_cb.state(["!disabled"])
+
     def _sync_mirror_widgets(self) -> None:
         on = self._mirror_var.get()
         state = tk.NORMAL if on else tk.DISABLED
@@ -229,7 +239,7 @@ class SharpBatchGui:
         mx = self._parse_max_splats() if lim else None
         if lim and mx is None:
             mx = 500_000
-        skip = self._skip_up_to_date_var.get()
+        skip = self._skip_up_to_date_var.get() and not self._force_all_var.get()
         mirror = self._mirror_var.get()
         m_out: Path | None = None
         i_root: Path | None = None

--- a/sharp_local_batch/gui.py
+++ b/sharp_local_batch/gui.py
@@ -6,6 +6,7 @@ import queue
 import sys
 import threading
 import tkinter as tk
+from collections.abc import Callable
 from pathlib import Path
 from tkinter import filedialog, messagebox, ttk
 
@@ -442,7 +443,7 @@ class SharpBatchGui:
                 self._snapshot_opts()
                 self._job_q.put(path)
 
-            self.root.after(0, push)
+            self._safe_after(0, push)
 
         self._watch = WatchController(
             root,
@@ -486,7 +487,7 @@ class SharpBatchGui:
                     ply_path=sidecar_ply_path(p),
                     message=str(e),
                 )
-                self.root.after(0, lambda res=r: self._on_job_done(res))
+                self._safe_after(0, self._on_job_done, r)
                 continue
 
             if skip and not needs_ply_refresh(p, ply_target):
@@ -505,7 +506,7 @@ class SharpBatchGui:
                     ply_output_path=ply_target,
                 )
 
-            self.root.after(0, lambda res=r: self._on_job_done(res))
+            self._safe_after(0, self._on_job_done, r)
 
     def _on_job_done(self, r: PlySidecarResult) -> None:
         if r.skipped:
@@ -534,6 +535,13 @@ class SharpBatchGui:
     def _log_line(self, text: str) -> None:
         self._log.insert(tk.END, text + "\n")
         self._log.see(tk.END)
+
+    def _safe_after(self, delay_ms: int, func: Callable[..., object], *args: object) -> None:
+        """Schedule on the Tk main loop; no-op if the root is already destroyed."""
+        try:
+            self.root.after(delay_ms, func, *args)
+        except tk.TclError:
+            pass
 
     def _on_close(self) -> None:
         self._stop_watch()

--- a/sharp_local_batch/gui.py
+++ b/sharp_local_batch/gui.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import queue
+import sys
 import threading
 import tkinter as tk
 from pathlib import Path
@@ -10,8 +11,12 @@ from tkinter import filedialog, messagebox, ttk
 
 from sharp_local_batch.batch_runner import WatchController, scan_jobs
 from sharp_local_batch.core import (
+    PHOTOS_LIBRARY_MIRROR_HELP,
     PlySidecarResult,
+    default_macos_photos_library_path,
+    is_photos_library_bundle,
     needs_ply_refresh,
+    output_ply_path_for_job,
     process_image_to_sidecar_ply,
     sidecar_ply_path,
 )
@@ -30,6 +35,9 @@ class SharpBatchGui:
         self._max_splats_var = tk.StringVar(value="500000")
         self._skip_up_to_date_var = tk.BooleanVar(value=True)
         self._watch_var = tk.BooleanVar(value=False)
+        self._mirror_var = tk.BooleanVar(value=False)
+        self._output_mirror_var = tk.StringVar(value="")
+        self._photos_lib_var = tk.BooleanVar(value=False)
 
         self._job_q: queue.Queue[Path] = queue.Queue()
         self._quit_app = threading.Event()
@@ -37,6 +45,8 @@ class SharpBatchGui:
         self._snap_lim = False
         self._snap_max: int | None = None
         self._snap_skip = True
+        self._snap_mirror_output: Path | None = None
+        self._snap_input_root: Path | None = None
         self._scan_running = False
         self._batch_total = 0
         self._batch_done = 0
@@ -62,6 +72,54 @@ class SharpBatchGui:
             side=tk.LEFT, fill=tk.X, expand=True, padx=(8, 4)
         )
         ttk.Button(row1, text="Browse…", command=self._browse).pack(side=tk.LEFT)
+
+        if sys.platform == "darwin":
+            row_pl = ttk.Frame(root_f)
+            row_pl.pack(fill=tk.X, **pad)
+            ttk.Checkbutton(
+                row_pl,
+                text=(
+                    "Use Apple Photos library bundle (Photos Library.photoslibrary; "
+                    "mirror required)"
+                ),
+                variable=self._photos_lib_var,
+                command=self._on_macos_photos_library_toggle,
+            ).pack(anchor=tk.W)
+
+        row1b = ttk.Frame(root_f)
+        row1b.pack(fill=tk.X, **pad)
+        self._mirror_cb = ttk.Checkbutton(
+            row1b,
+            text="Mirror PLY output (same subfolders under target)",
+            variable=self._mirror_var,
+        )
+        self._mirror_cb.pack(anchor=tk.W)
+        ttk.Label(
+            root_f,
+            text=(
+                "Example: ~/Photos/source/folder1/example.jpg → "
+                "target_mirror/Photos/source/folder1/example.ply "
+                "(path under the mirror target repeats from your home folder)."
+            ),
+            wraplength=520,
+            foreground="#666",
+        ).pack(anchor=tk.W, padx=10, pady=(0, 2))
+
+        row1c = ttk.Frame(root_f)
+        row1c.pack(fill=tk.X, **pad)
+        ttk.Label(row1c, text="Target folder for mirror").pack(side=tk.LEFT)
+        self._output_mirror_entry = ttk.Entry(
+            row1c, textvariable=self._output_mirror_var, width=40
+        )
+        self._output_mirror_entry.pack(
+            side=tk.LEFT, fill=tk.X, expand=True, padx=(8, 4)
+        )
+        self._mirror_browse_btn = ttk.Button(
+            row1c, text="Browse…", command=self._browse_mirror
+        )
+        self._mirror_browse_btn.pack(side=tk.LEFT)
+        self._mirror_var.trace_add("write", lambda *_: self._sync_mirror_widgets())
+        self._sync_mirror_widgets()
 
         row2 = ttk.Frame(root_f)
         row2.pack(fill=tk.X, **pad)
@@ -122,8 +180,9 @@ class SharpBatchGui:
         scroll.pack(side=tk.RIGHT, fill=tk.Y)
 
         hint = (
-            "Writes <name>.ply next to each image. "
-            "Optional cap uses splat-transform (npm i -g @playcanvas/splat-transform)."
+            "PLY next to each image when mirror output is off; with mirror on, PLY goes "
+            "under the target folder for mirror. Optional cap uses splat-transform "
+            "(npm i -g @playcanvas/splat-transform)."
         )
         ttk.Label(root_f, text=hint, wraplength=500, foreground="#666").pack(
             fill=tk.X, **pad
@@ -133,10 +192,37 @@ class SharpBatchGui:
         on = self._limit_var.get()
         self._max_entry.configure(state=tk.NORMAL if on else "disabled")
 
+    def _sync_mirror_widgets(self) -> None:
+        on = self._mirror_var.get()
+        state = tk.NORMAL if on else tk.DISABLED
+        self._output_mirror_entry.configure(state=state)
+        self._mirror_browse_btn.configure(state=state)
+
     def _browse(self) -> None:
         d = filedialog.askdirectory()
         if d:
             self._folder_var.set(d)
+
+    def _browse_mirror(self) -> None:
+        d = filedialog.askdirectory()
+        if d:
+            self._output_mirror_var.set(d)
+
+    def _on_macos_photos_library_toggle(self) -> None:
+        if not self._photos_lib_var.get():
+            self._mirror_cb.state(["!disabled"])
+            return
+        lib = default_macos_photos_library_path()
+        if not lib.is_dir():
+            messagebox.showwarning(
+                "Apple Photos library",
+                f"Photos Library.photoslibrary not found:\n{lib}",
+            )
+            self._photos_lib_var.set(False)
+            return
+        self._folder_var.set(str(lib))
+        self._mirror_var.set(True)
+        self._mirror_cb.state(["disabled"])
 
     def _snapshot_opts(self) -> None:
         lim = self._limit_var.get()
@@ -144,10 +230,27 @@ class SharpBatchGui:
         if lim and mx is None:
             mx = 500_000
         skip = self._skip_up_to_date_var.get()
+        mirror = self._mirror_var.get()
+        m_out: Path | None = None
+        i_root: Path | None = None
+        if mirror:
+            mor = self._output_mirror_var.get().strip()
+            if mor:
+                m_out = Path(mor).expanduser().resolve()
+            if sys.platform == "darwin" and self._photos_lib_var.get():
+                lib = default_macos_photos_library_path().expanduser().resolve()
+                if lib.is_dir():
+                    i_root = lib
+            else:
+                fr = self._folder_var.get().strip()
+                if fr:
+                    i_root = Path(fr).expanduser().resolve()
         with self._opts_lock:
             self._snap_lim = bool(lim)
             self._snap_max = mx if lim else None
             self._snap_skip = skip
+            self._snap_mirror_output = m_out
+            self._snap_input_root = i_root
 
     def _parse_max_splats(self) -> int | None:
         if not self._limit_var.get():
@@ -176,19 +279,52 @@ class SharpBatchGui:
         ok, max_s = self._limit_options()
         if not ok:
             return
-        raw = self._folder_var.get().strip()
-        if not raw:
-            messagebox.showwarning("Folder", "Choose a folder first.")
-            return
-        root = Path(raw).expanduser()
-        if not root.is_dir():
-            messagebox.showerror("Folder", f"Not a directory: {root}")
+        if sys.platform == "darwin" and self._photos_lib_var.get():
+            root = default_macos_photos_library_path().expanduser().resolve()
+            if not root.is_dir():
+                messagebox.showerror(
+                    "Apple Photos library",
+                    f"Photos Library.photoslibrary not found:\n{root}",
+                )
+                return
+            self._folder_var.set(str(root))
+        else:
+            raw = self._folder_var.get().strip()
+            if not raw:
+                messagebox.showwarning("Folder", "Choose a folder first.")
+                return
+            root = Path(raw).expanduser().resolve()
+            if not root.is_dir():
+                messagebox.showerror("Folder", f"Not a directory: {root}")
+                return
+
+        mirror_out: Path | None = None
+        if self._mirror_var.get():
+            mor = self._output_mirror_var.get().strip()
+            if not mor:
+                messagebox.showwarning(
+                    "Mirror output",
+                    "Choose a target folder for mirror, or turn off mirroring.",
+                )
+                return
+            mirror_out = Path(mor).expanduser().resolve()
+            if mirror_out == root:
+                messagebox.showerror(
+                    "Mirror output",
+                    "Target folder for mirror must differ from the source folder.",
+                )
+                return
+            mirror_out.mkdir(parents=True, exist_ok=True)
+
+        if is_photos_library_bundle(root) and mirror_out is None:
+            messagebox.showerror("Apple Photos library", PHOTOS_LIBRARY_MIRROR_HELP)
             return
 
         jobs = scan_jobs(
             root,
             self._recursive_var.get(),
             force_all=self._force_all_var.get(),
+            mirror_output_root=mirror_out,
         )
         if not jobs:
             messagebox.showinfo("Scan", "No images need processing (PLY already fresh).")
@@ -229,19 +365,63 @@ class SharpBatchGui:
         if not ok:
             self._watch_var.set(False)
             return
-        raw = self._folder_var.get().strip()
-        if not raw:
-            messagebox.showwarning("Watch", "Choose a folder first.")
-            self._watch_var.set(False)
-            return
-        root = Path(raw).expanduser()
-        if not root.is_dir():
-            messagebox.showerror("Watch", f"Not a directory: {root}")
+        if sys.platform == "darwin" and self._photos_lib_var.get():
+            root = default_macos_photos_library_path().expanduser().resolve()
+            if not root.is_dir():
+                messagebox.showerror(
+                    "Watch",
+                    f"Photos Library.photoslibrary not found:\n{root}",
+                )
+                self._watch_var.set(False)
+                return
+            self._folder_var.set(str(root))
+        else:
+            raw = self._folder_var.get().strip()
+            if not raw:
+                messagebox.showwarning("Watch", "Choose a folder first.")
+                self._watch_var.set(False)
+                return
+            root = Path(raw).expanduser().resolve()
+            if not root.is_dir():
+                messagebox.showerror("Watch", f"Not a directory: {root}")
+                self._watch_var.set(False)
+                return
+
+        if self._mirror_var.get():
+            mor = self._output_mirror_var.get().strip()
+            if not mor:
+                messagebox.showwarning(
+                    "Watch",
+                    "Choose a target folder for mirror, or disable mirroring.",
+                )
+                self._watch_var.set(False)
+                return
+            if Path(mor).expanduser().resolve() == root:
+                messagebox.showerror(
+                    "Watch",
+                    "Target folder for mirror must differ from the watched folder.",
+                )
+                self._watch_var.set(False)
+                return
+
+        mirror_out_watch: Path | None = None
+        if self._mirror_var.get():
+            mirror_out_watch = Path(self._output_mirror_var.get().strip()).expanduser().resolve()
+        if is_photos_library_bundle(root) and mirror_out_watch is None:
+            messagebox.showerror("Watch", PHOTOS_LIBRARY_MIRROR_HELP)
             self._watch_var.set(False)
             return
 
         if self._watch is not None:
             return
+
+        if is_photos_library_bundle(root):
+            messagebox.showinfo(
+                "Watch",
+                "Watching Photos Library.photoslibrary can fire often while the Photos "
+                "app updates its database. Exporting to a normal folder is gentler if "
+                "you hit issues.",
+            )
 
         self._snapshot_opts()
 
@@ -280,12 +460,30 @@ class SharpBatchGui:
                 lim = self._snap_lim
                 max_s = self._snap_max
                 skip = self._snap_skip
+                m_out = self._snap_mirror_output
+                i_root = self._snap_input_root
 
-            if skip and not needs_ply_refresh(p):
+            try:
+                ply_target = output_ply_path_for_job(
+                    p,
+                    mirror_output_root=m_out,
+                    mirror_input_root=i_root,
+                )
+            except ValueError as e:
+                r = PlySidecarResult(
+                    ok=False,
+                    image_path=p,
+                    ply_path=sidecar_ply_path(p),
+                    message=str(e),
+                )
+                self.root.after(0, lambda res=r: self._on_job_done(res))
+                continue
+
+            if skip and not needs_ply_refresh(p, ply_target):
                 r = PlySidecarResult(
                     ok=True,
                     image_path=p,
-                    ply_path=sidecar_ply_path(p),
+                    ply_path=ply_target,
                     message="Skipped (PLY up to date)",
                     skipped=True,
                 )
@@ -294,6 +492,7 @@ class SharpBatchGui:
                     p,
                     limit_splats=lim,
                     max_splats=max_s if lim else None,
+                    ply_output_path=ply_target,
                 )
 
             self.root.after(0, lambda res=r: self._on_job_done(res))

--- a/sharp_local_batch/gui.py
+++ b/sharp_local_batch/gui.py
@@ -340,14 +340,26 @@ class SharpBatchGui:
             messagebox.showerror("Apple Photos library", PHOTOS_LIBRARY_MIRROR_HELP)
             return
 
-        jobs = scan_jobs(
+        jobs, total_found = scan_jobs(
             root,
             self._recursive_var.get(),
             force_all=self._force_all_var.get(),
             mirror_output_root=mirror_out,
         )
         if not jobs:
-            messagebox.showinfo("Scan", "No images need processing (PLY already fresh).")
+            if total_found == 0:
+                messagebox.showinfo(
+                    "Scan",
+                    "No supported images were found in the scan folder.\n\n"
+                    "If you use iCloud Photos, originals may not be on disk yet — "
+                    "open a photo in Photos to download it, or enable "
+                    "Photos → Settings → iCloud → Download Originals to this Mac.",
+                )
+            else:
+                messagebox.showinfo(
+                    "Scan",
+                    "No images need processing (PLY already up to date).",
+                )
             return
 
         self._snapshot_opts()

--- a/sharp_local_batch/gui_qt.py
+++ b/sharp_local_batch/gui_qt.py
@@ -1,0 +1,346 @@
+"""Qt (PySide6) UI — works with Homebrew Python without system Tcl/Tk."""
+
+from __future__ import annotations
+
+import queue
+import threading
+from pathlib import Path
+
+from PySide6.QtCore import QObject, Qt, Signal, Slot
+from PySide6.QtGui import QCloseEvent
+from PySide6.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QFileDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMainWindow,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QTextEdit,
+    QVBoxLayout,
+    QWidget,
+)
+
+from sharp_local_batch.batch_runner import WatchController, scan_jobs
+from sharp_local_batch.core import (
+    PlySidecarResult,
+    needs_ply_refresh,
+    process_image_to_sidecar_ply,
+    sidecar_ply_path,
+)
+
+
+class _Bridge(QObject):
+    """Cross-thread signals (Qt delivers slots on the GUI thread)."""
+
+    job_finished = Signal(object)
+    watch_enqueue = Signal(object)
+
+
+class SharpBatchQtWindow(QMainWindow):
+    def __init__(self) -> None:
+        super().__init__()
+        self.setWindowTitle("sharp_local_batch")
+        self.resize(580, 520)
+
+        self._job_q: queue.Queue[Path] = queue.Queue()
+        self._quit_app = threading.Event()
+        self._opts_lock = threading.Lock()
+        self._snap_lim = False
+        self._snap_max: int | None = None
+        self._snap_skip = True
+        self._batch_total = 0
+        self._batch_done = 0
+        self._watch: WatchController | None = None
+        self._processed_session = 0
+
+        self._bridge = _Bridge()
+        self._bridge.job_finished.connect(self._on_job_done, Qt.QueuedConnection)
+        self._bridge.watch_enqueue.connect(self._on_watch_enqueue, Qt.QueuedConnection)
+
+        central = QWidget()
+        self.setCentralWidget(central)
+        layout = QVBoxLayout(central)
+
+        row1 = QHBoxLayout()
+        row1.addWidget(QLabel("Folder"))
+        self._folder_edit = QLineEdit()
+        row1.addWidget(self._folder_edit, stretch=1)
+        browse = QPushButton("Browse…")
+        browse.clicked.connect(self._browse)
+        row1.addWidget(browse)
+        layout.addLayout(row1)
+
+        row2 = QHBoxLayout()
+        self._recursive_chk = QCheckBox("Include subfolders")
+        self._recursive_chk.setChecked(True)
+        row2.addWidget(self._recursive_chk)
+        self._force_all_chk = QCheckBox("Reprocess all (ignore PLY freshness)")
+        row2.addWidget(self._force_all_chk)
+        layout.addLayout(row2)
+
+        row3 = QHBoxLayout()
+        self._limit_chk = QCheckBox("Limit splat count")
+        row3.addWidget(self._limit_chk)
+        row3.addWidget(QLabel("Max splats"))
+        self._max_edit = QLineEdit("500000")
+        self._max_edit.setMaximumWidth(120)
+        row3.addWidget(self._max_edit)
+        self._skip_chk = QCheckBox("Skip up-to-date PLY")
+        self._skip_chk.setChecked(True)
+        row3.addWidget(self._skip_chk)
+        row3.addStretch()
+        layout.addLayout(row3)
+        self._limit_chk.toggled.connect(self._sync_limit_widgets)
+        self._sync_limit_widgets()
+
+        row4 = QHBoxLayout()
+        scan_btn = QPushButton("Scan & queue jobs")
+        scan_btn.clicked.connect(self._on_scan)
+        row4.addWidget(scan_btn)
+        stop_btn = QPushButton("Stop")
+        stop_btn.clicked.connect(self._on_stop)
+        row4.addWidget(stop_btn)
+        self._watch_chk = QCheckBox("Watch folder (new / changed images)")
+        self._watch_chk.toggled.connect(self._on_watch_toggled)
+        row4.addWidget(self._watch_chk)
+        layout.addLayout(row4)
+
+        layout.addWidget(QLabel("Batch progress"))
+        self._progress = QProgressBar()
+        self._progress.setRange(0, 100)
+        self._progress.setValue(0)
+        layout.addWidget(self._progress)
+        self._progress_label = QLabel("—")
+        layout.addWidget(self._progress_label)
+
+        log_label = QLabel("Log")
+        layout.addWidget(log_label)
+        self._log = QTextEdit()
+        self._log.setReadOnly(True)
+        self._log.setMinimumHeight(200)
+        layout.addWidget(self._log, stretch=1)
+
+        hint = (
+            "Writes <name>.ply next to each image. "
+            "Optional cap uses splat-transform (npm i -g @playcanvas/splat-transform)."
+        )
+        foot = QLabel(hint)
+        foot.setWordWrap(True)
+        foot.setStyleSheet("color: #666;")
+        layout.addWidget(foot)
+
+        threading.Thread(target=self._worker_loop, daemon=True).start()
+
+    def _sync_limit_widgets(self) -> None:
+        self._max_edit.setEnabled(self._limit_chk.isChecked())
+
+    def _browse(self) -> None:
+        d = QFileDialog.getExistingDirectory(self, "Select folder")
+        if d:
+            self._folder_edit.setText(d)
+
+    def _snapshot_opts(self) -> None:
+        lim = self._limit_chk.isChecked()
+        mx = self._parse_max_splats() if lim else None
+        if lim and mx is None:
+            mx = 500_000
+        skip = self._skip_chk.isChecked()
+        with self._opts_lock:
+            self._snap_lim = bool(lim)
+            self._snap_max = mx if lim else None
+            self._snap_skip = skip
+
+    def _parse_max_splats(self) -> int | None:
+        if not self._limit_chk.isChecked():
+            return None
+        raw = self._max_edit.text().strip()
+        try:
+            n = int(raw, 10)
+        except ValueError:
+            return None
+        if n < 1:
+            return None
+        return min(n, 10_000_000)
+
+    def _limit_options_valid(self) -> bool:
+        if not self._limit_chk.isChecked():
+            return True
+        if self._parse_max_splats() is None:
+            QMessageBox.critical(
+                self,
+                "Invalid max splats",
+                "Enter a positive integer for max splats when limit is enabled.",
+            )
+            return False
+        return True
+
+    @Slot()
+    def _on_scan(self) -> None:
+        if not self._limit_options_valid():
+            return
+        raw = self._folder_edit.text().strip()
+        if not raw:
+            QMessageBox.warning(self, "Folder", "Choose a folder first.")
+            return
+        root = Path(raw).expanduser()
+        if not root.is_dir():
+            QMessageBox.critical(self, "Folder", f"Not a directory: {root}")
+            return
+
+        jobs = scan_jobs(
+            root,
+            self._recursive_chk.isChecked(),
+            force_all=self._force_all_chk.isChecked(),
+        )
+        if not jobs:
+            QMessageBox.information(self, "Scan", "No images need processing (PLY already fresh).")
+            return
+
+        self._snapshot_opts()
+        self._batch_total = len(jobs)
+        self._batch_done = 0
+        self._progress.setMaximum(self._batch_total)
+        self._progress.setValue(0)
+        self._progress_label.setText(f"Queued {len(jobs)} job(s)…")
+        self._log_line(f"--- Scan: {len(jobs)} job(s) ---")
+        for p in jobs:
+            self._job_q.put(p)
+
+    @Slot()
+    def _on_stop(self) -> None:
+        try:
+            while True:
+                self._job_q.get_nowait()
+        except queue.Empty:
+            pass
+        self._batch_total = 0
+        self._batch_done = 0
+        self._progress.setValue(0)
+        self._progress.setMaximum(100)
+        self._progress_label.setText("Stopped")
+        self._log_line("--- Stop: queue cleared ---")
+
+    @Slot(bool)
+    def _on_watch_toggled(self, checked: bool) -> None:
+        if checked:
+            self._start_watch()
+        else:
+            self._stop_watch()
+
+    def _start_watch(self) -> None:
+        if not self._limit_options_valid():
+            self._watch_chk.setChecked(False)
+            return
+        raw = self._folder_edit.text().strip()
+        if not raw:
+            QMessageBox.warning(self, "Watch", "Choose a folder first.")
+            self._watch_chk.setChecked(False)
+            return
+        root = Path(raw).expanduser()
+        if not root.is_dir():
+            QMessageBox.critical(self, "Watch", f"Not a directory: {root}")
+            self._watch_chk.setChecked(False)
+            return
+        if self._watch is not None:
+            return
+        self._snapshot_opts()
+
+        def enqueue(p: Path) -> None:
+            self._bridge.watch_enqueue.emit(p.resolve())
+
+        self._watch = WatchController(
+            root,
+            enqueue,
+            debounce_sec=0.6,
+            recursive=self._recursive_chk.isChecked(),
+        )
+        self._watch.start()
+        self._log_line(f"--- Watch started: {root} ---")
+
+    def _stop_watch(self) -> None:
+        if self._watch is not None:
+            self._watch.stop()
+            self._watch = None
+            self._log_line("--- Watch stopped ---")
+
+    @Slot(object)
+    def _on_watch_enqueue(self, p: object) -> None:
+        if not isinstance(p, Path):
+            p = Path(p)
+        self._snapshot_opts()
+        self._job_q.put(p.resolve())
+
+    def _worker_loop(self) -> None:
+        while not self._quit_app.is_set():
+            try:
+                item = self._job_q.get(timeout=0.35)
+            except queue.Empty:
+                continue
+            with self._opts_lock:
+                lim = self._snap_lim
+                max_s = self._snap_max
+                skip = self._snap_skip
+            if skip and not needs_ply_refresh(item):
+                r = PlySidecarResult(
+                    ok=True,
+                    image_path=item,
+                    ply_path=sidecar_ply_path(item),
+                    message="Skipped (PLY up to date)",
+                    skipped=True,
+                )
+            else:
+                r = process_image_to_sidecar_ply(
+                    item,
+                    limit_splats=lim,
+                    max_splats=max_s if lim else None,
+                )
+            self._bridge.job_finished.emit(r)
+
+    @Slot(object)
+    def _on_job_done(self, r: object) -> None:
+        if not isinstance(r, PlySidecarResult):
+            return
+        if r.skipped:
+            self._log_line(f"[skip] {r.image_path.name} — {r.message}")
+        elif r.ok:
+            self._processed_session += 1
+            self._log_line(f"[ok] {r.image_path.name} — {r.message}")
+        else:
+            self._log_line(f"[err] {r.image_path.name} — {r.message}")
+
+        if self._batch_total > 0:
+            self._batch_done += 1
+            self._progress.setValue(self._batch_done)
+            self._progress_label.setText(
+                f"{self._batch_done} / {self._batch_total} files"
+            )
+            if self._batch_done >= self._batch_total:
+                self._batch_total = 0
+                self._batch_done = 0
+                self._progress.setValue(0)
+                self._progress.setMaximum(100)
+                self._progress_label.setText(
+                    f"Batch done · session processed: {self._processed_session}"
+                )
+
+    def _log_line(self, text: str) -> None:
+        self._log.append(text)
+
+    def closeEvent(self, event: QCloseEvent) -> None:
+        self._stop_watch()
+        self._quit_app.set()
+        event.accept()
+
+
+def main() -> None:
+    import sys
+
+    app = QApplication(sys.argv)
+    win = SharpBatchQtWindow()
+    win.show()
+    sys.exit(app.exec())

--- a/sharp_local_batch/gui_qt.py
+++ b/sharp_local_batch/gui_qt.py
@@ -440,6 +440,8 @@ class SharpBatchQtWindow(QMainWindow):
         self._snapshot_opts()
 
         def enqueue(p: Path) -> None:
+            if self._quit_app.is_set():
+                return
             self._bridge.watch_enqueue.emit(p.resolve())
 
         self._watch = WatchController(
@@ -459,6 +461,8 @@ class SharpBatchQtWindow(QMainWindow):
 
     @Slot(object)
     def _on_watch_enqueue(self, p: object) -> None:
+        if self._quit_app.is_set():
+            return
         if not isinstance(p, Path):
             p = Path(p)
         self._snapshot_opts()
@@ -483,14 +487,15 @@ class SharpBatchQtWindow(QMainWindow):
                     mirror_input_root=i_root,
                 )
             except ValueError as e:
-                self._bridge.job_finished.emit(
-                    PlySidecarResult(
-                        ok=False,
-                        image_path=item,
-                        ply_path=sidecar_ply_path(item),
-                        message=str(e),
-                    )
+                r = PlySidecarResult(
+                    ok=False,
+                    image_path=item,
+                    ply_path=sidecar_ply_path(item),
+                    message=str(e),
                 )
+                if self._quit_app.is_set():
+                    break
+                self._bridge.job_finished.emit(r)
                 continue
             if skip and not needs_ply_refresh(item, ply_target):
                 r = PlySidecarResult(
@@ -507,10 +512,14 @@ class SharpBatchQtWindow(QMainWindow):
                     max_splats=max_s if lim else None,
                     ply_output_path=ply_target,
                 )
+            if self._quit_app.is_set():
+                break
             self._bridge.job_finished.emit(r)
 
     @Slot(object)
     def _on_job_done(self, r: object) -> None:
+        if self._quit_app.is_set():
+            return
         if not isinstance(r, PlySidecarResult):
             return
         if r.skipped:

--- a/sharp_local_batch/gui_qt.py
+++ b/sharp_local_batch/gui_qt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import queue
+import sys
 import threading
 from pathlib import Path
 
@@ -27,8 +28,12 @@ from PySide6.QtWidgets import (
 
 from sharp_local_batch.batch_runner import WatchController, scan_jobs
 from sharp_local_batch.core import (
+    PHOTOS_LIBRARY_MIRROR_HELP,
     PlySidecarResult,
+    default_macos_photos_library_path,
+    is_photos_library_bundle,
     needs_ply_refresh,
+    output_ply_path_for_job,
     process_image_to_sidecar_ply,
     sidecar_ply_path,
 )
@@ -57,6 +62,8 @@ class SharpBatchQtWindow(QMainWindow):
         self._batch_done = 0
         self._watch: WatchController | None = None
         self._processed_session = 0
+        self._snap_mirror_output: Path | None = None
+        self._snap_input_root: Path | None = None
 
         self._bridge = _Bridge()
         self._bridge.job_finished.connect(self._on_job_done, Qt.QueuedConnection)
@@ -74,6 +81,39 @@ class SharpBatchQtWindow(QMainWindow):
         browse.clicked.connect(self._browse)
         row1.addWidget(browse)
         layout.addLayout(row1)
+
+        self._photos_lib_chk: QCheckBox | None = None
+        if sys.platform == "darwin":
+            self._photos_lib_chk = QCheckBox(
+                "Use Apple Photos library bundle (Photos Library.photoslibrary; "
+                "mirror required)"
+            )
+            self._photos_lib_chk.toggled.connect(self._on_photos_lib_toggled)
+            layout.addWidget(self._photos_lib_chk)
+
+        row1b = QHBoxLayout()
+        self._mirror_chk = QCheckBox("Mirror PLY output (same subfolders under target)")
+        self._mirror_chk.toggled.connect(self._sync_mirror_widgets)
+        row1b.addWidget(self._mirror_chk)
+        layout.addLayout(row1b)
+        mirror_hint = QLabel(
+            "Example: ~/Photos/source/folder1/example.jpg → "
+            "target_mirror/Photos/source/folder1/example.ply "
+            "(path under the mirror target repeats from your home folder)."
+        )
+        mirror_hint.setWordWrap(True)
+        mirror_hint.setStyleSheet("color: #666;")
+        layout.addWidget(mirror_hint)
+
+        row1c = QHBoxLayout()
+        row1c.addWidget(QLabel("Target folder for mirror"))
+        self._output_mirror_edit = QLineEdit()
+        row1c.addWidget(self._output_mirror_edit, stretch=1)
+        self._mirror_browse_btn = QPushButton("Browse…")
+        self._mirror_browse_btn.clicked.connect(self._browse_mirror)
+        row1c.addWidget(self._mirror_browse_btn)
+        layout.addLayout(row1c)
+        self._sync_mirror_widgets(False)
 
         row2 = QHBoxLayout()
         self._recursive_chk = QCheckBox("Include subfolders")
@@ -126,8 +166,9 @@ class SharpBatchQtWindow(QMainWindow):
         layout.addWidget(self._log, stretch=1)
 
         hint = (
-            "Writes <name>.ply next to each image. "
-            "Optional cap uses splat-transform (npm i -g @playcanvas/splat-transform)."
+            "PLY next to each image when mirror output is off; with mirror on, PLY goes "
+            "under the target folder for mirror. Optional cap uses splat-transform "
+            "(npm i -g @playcanvas/splat-transform)."
         )
         foot = QLabel(hint)
         foot.setWordWrap(True)
@@ -139,10 +180,45 @@ class SharpBatchQtWindow(QMainWindow):
     def _sync_limit_widgets(self) -> None:
         self._max_edit.setEnabled(self._limit_chk.isChecked())
 
+    def _sync_mirror_widgets(self, _checked: bool) -> None:
+        on = self._mirror_chk.isChecked()
+        self._output_mirror_edit.setEnabled(on)
+        self._mirror_browse_btn.setEnabled(on)
+
     def _browse(self) -> None:
         d = QFileDialog.getExistingDirectory(self, "Select folder")
         if d:
             self._folder_edit.setText(d)
+
+    def _browse_mirror(self) -> None:
+        d = QFileDialog.getExistingDirectory(self, "Select target folder for mirror")
+        if d:
+            self._output_mirror_edit.setText(d)
+
+    @Slot(bool)
+    def _on_photos_lib_toggled(self, checked: bool) -> None:
+        if not checked:
+            self._mirror_chk.setEnabled(True)
+            return
+        lib = default_macos_photos_library_path()
+        if not lib.is_dir():
+            QMessageBox.warning(
+                self,
+                "Apple Photos library",
+                f"Photos Library.photoslibrary not found:\n{lib}",
+            )
+            self._photos_lib_chk.setChecked(False)
+            return
+        self._folder_edit.setText(str(lib))
+        self._mirror_chk.setChecked(True)
+        self._mirror_chk.setEnabled(False)
+
+    def _apple_photos_bundle_mode(self) -> bool:
+        return (
+            sys.platform == "darwin"
+            and self._photos_lib_chk is not None
+            and self._photos_lib_chk.isChecked()
+        )
 
     def _snapshot_opts(self) -> None:
         lim = self._limit_chk.isChecked()
@@ -150,10 +226,27 @@ class SharpBatchQtWindow(QMainWindow):
         if lim and mx is None:
             mx = 500_000
         skip = self._skip_chk.isChecked()
+        mirror = self._mirror_chk.isChecked()
+        m_out: Path | None = None
+        i_root: Path | None = None
+        if mirror:
+            mor = self._output_mirror_edit.text().strip()
+            if mor:
+                m_out = Path(mor).expanduser().resolve()
+            if self._apple_photos_bundle_mode():
+                lib = default_macos_photos_library_path().expanduser().resolve()
+                if lib.is_dir():
+                    i_root = lib
+            else:
+                fr = self._folder_edit.text().strip()
+                if fr:
+                    i_root = Path(fr).expanduser().resolve()
         with self._opts_lock:
             self._snap_lim = bool(lim)
             self._snap_max = mx if lim else None
             self._snap_skip = skip
+            self._snap_mirror_output = m_out
+            self._snap_input_root = i_root
 
     def _parse_max_splats(self) -> int | None:
         if not self._limit_chk.isChecked():
@@ -183,19 +276,55 @@ class SharpBatchQtWindow(QMainWindow):
     def _on_scan(self) -> None:
         if not self._limit_options_valid():
             return
-        raw = self._folder_edit.text().strip()
-        if not raw:
-            QMessageBox.warning(self, "Folder", "Choose a folder first.")
-            return
-        root = Path(raw).expanduser()
-        if not root.is_dir():
-            QMessageBox.critical(self, "Folder", f"Not a directory: {root}")
+        if self._apple_photos_bundle_mode():
+            root = default_macos_photos_library_path().expanduser().resolve()
+            if not root.is_dir():
+                QMessageBox.critical(
+                    self,
+                    "Apple Photos library",
+                    f"Photos Library.photoslibrary not found:\n{root}",
+                )
+                return
+            self._folder_edit.setText(str(root))
+        else:
+            raw = self._folder_edit.text().strip()
+            if not raw:
+                QMessageBox.warning(self, "Folder", "Choose a folder first.")
+                return
+            root = Path(raw).expanduser().resolve()
+            if not root.is_dir():
+                QMessageBox.critical(self, "Folder", f"Not a directory: {root}")
+                return
+
+        mirror_out: Path | None = None
+        if self._mirror_chk.isChecked():
+            mor = self._output_mirror_edit.text().strip()
+            if not mor:
+                QMessageBox.warning(
+                    self,
+                    "Mirror output",
+                    "Choose a target folder for mirror, or disable mirroring.",
+                )
+                return
+            mirror_out = Path(mor).expanduser().resolve()
+            if mirror_out == root:
+                QMessageBox.critical(
+                    self,
+                    "Mirror output",
+                    "Target folder for mirror must differ from the source folder.",
+                )
+                return
+            mirror_out.mkdir(parents=True, exist_ok=True)
+
+        if is_photos_library_bundle(root) and mirror_out is None:
+            QMessageBox.critical(self, "Apple Photos library", PHOTOS_LIBRARY_MIRROR_HELP)
             return
 
         jobs = scan_jobs(
             root,
             self._recursive_chk.isChecked(),
             force_all=self._force_all_chk.isChecked(),
+            mirror_output_root=mirror_out,
         )
         if not jobs:
             QMessageBox.information(self, "Scan", "No images need processing (PLY already fresh).")
@@ -236,18 +365,69 @@ class SharpBatchQtWindow(QMainWindow):
         if not self._limit_options_valid():
             self._watch_chk.setChecked(False)
             return
-        raw = self._folder_edit.text().strip()
-        if not raw:
-            QMessageBox.warning(self, "Watch", "Choose a folder first.")
+        if self._apple_photos_bundle_mode():
+            root = default_macos_photos_library_path().expanduser().resolve()
+            if not root.is_dir():
+                QMessageBox.critical(
+                    self,
+                    "Apple Photos library",
+                    f"Photos Library.photoslibrary not found:\n{root}",
+                )
+                self._watch_chk.setChecked(False)
+                return
+            self._folder_edit.setText(str(root))
+        else:
+            raw = self._folder_edit.text().strip()
+            if not raw:
+                QMessageBox.warning(self, "Watch", "Choose a folder first.")
+                self._watch_chk.setChecked(False)
+                return
+            root = Path(raw).expanduser().resolve()
+            if not root.is_dir():
+                QMessageBox.critical(self, "Watch", f"Not a directory: {root}")
+                self._watch_chk.setChecked(False)
+                return
+        if self._mirror_chk.isChecked():
+            mor = self._output_mirror_edit.text().strip()
+            if not mor:
+                QMessageBox.warning(
+                    self,
+                    "Watch",
+                    "Choose a target folder for mirror, or disable mirroring.",
+                )
+                self._watch_chk.setChecked(False)
+                return
+            if Path(mor).expanduser().resolve() == root:
+                QMessageBox.critical(
+                    self,
+                    "Watch",
+                    "Target folder for mirror must differ from the watched folder.",
+                )
+                self._watch_chk.setChecked(False)
+                return
+
+        mirror_out_watch: Path | None = None
+        if self._mirror_chk.isChecked():
+            mor_w = self._output_mirror_edit.text().strip()
+            if mor_w:
+                mirror_out_watch = Path(mor_w).expanduser().resolve()
+        if is_photos_library_bundle(root) and mirror_out_watch is None:
+            QMessageBox.critical(self, "Watch", PHOTOS_LIBRARY_MIRROR_HELP)
             self._watch_chk.setChecked(False)
             return
-        root = Path(raw).expanduser()
-        if not root.is_dir():
-            QMessageBox.critical(self, "Watch", f"Not a directory: {root}")
-            self._watch_chk.setChecked(False)
-            return
+
         if self._watch is not None:
             return
+
+        if is_photos_library_bundle(root):
+            QMessageBox.information(
+                self,
+                "Watch",
+                "Watching Photos Library.photoslibrary can fire often while the Photos "
+                "app updates its database. Exporting to a normal folder is gentler if "
+                "you hit issues.",
+            )
+
         self._snapshot_opts()
 
         def enqueue(p: Path) -> None:
@@ -285,11 +465,29 @@ class SharpBatchQtWindow(QMainWindow):
                 lim = self._snap_lim
                 max_s = self._snap_max
                 skip = self._snap_skip
-            if skip and not needs_ply_refresh(item):
+                m_out = self._snap_mirror_output
+                i_root = self._snap_input_root
+            try:
+                ply_target = output_ply_path_for_job(
+                    item,
+                    mirror_output_root=m_out,
+                    mirror_input_root=i_root,
+                )
+            except ValueError as e:
+                self._bridge.job_finished.emit(
+                    PlySidecarResult(
+                        ok=False,
+                        image_path=item,
+                        ply_path=sidecar_ply_path(item),
+                        message=str(e),
+                    )
+                )
+                continue
+            if skip and not needs_ply_refresh(item, ply_target):
                 r = PlySidecarResult(
                     ok=True,
                     image_path=item,
-                    ply_path=sidecar_ply_path(item),
+                    ply_path=ply_target,
                     message="Skipped (PLY up to date)",
                     skipped=True,
                 )
@@ -298,6 +496,7 @@ class SharpBatchQtWindow(QMainWindow):
                     item,
                     limit_splats=lim,
                     max_splats=max_s if lim else None,
+                    ply_output_path=ply_target,
                 )
             self._bridge.job_finished.emit(r)
 

--- a/sharp_local_batch/gui_qt.py
+++ b/sharp_local_batch/gui_qt.py
@@ -85,11 +85,18 @@ class SharpBatchQtWindow(QMainWindow):
         self._photos_lib_chk: QCheckBox | None = None
         if sys.platform == "darwin":
             self._photos_lib_chk = QCheckBox(
-                "Use Apple Photos library bundle (Photos Library.photoslibrary; "
-                "mirror required)"
+                "Use system Photos library as source folder "
+                "(Photos Library.photoslibrary; mirror required)"
             )
             self._photos_lib_chk.toggled.connect(self._on_photos_lib_toggled)
             layout.addWidget(self._photos_lib_chk)
+            _photos_hint = QLabel(
+                "Fills the Folder field above — one source only, not an extra path. "
+                "Uncheck to browse your own folder."
+            )
+            _photos_hint.setWordWrap(True)
+            _photos_hint.setStyleSheet("color: #666; margin-left: 22px;")
+            layout.addWidget(_photos_hint)
 
         row1b = QHBoxLayout()
         self._mirror_chk = QCheckBox("Mirror PLY output (same subfolders under target)")

--- a/sharp_local_batch/gui_qt.py
+++ b/sharp_local_batch/gui_qt.py
@@ -120,6 +120,7 @@ class SharpBatchQtWindow(QMainWindow):
         self._recursive_chk.setChecked(True)
         row2.addWidget(self._recursive_chk)
         self._force_all_chk = QCheckBox("Reprocess all (ignore PLY freshness)")
+        self._force_all_chk.toggled.connect(self._sync_force_skip_widgets)
         row2.addWidget(self._force_all_chk)
         layout.addLayout(row2)
 
@@ -137,6 +138,7 @@ class SharpBatchQtWindow(QMainWindow):
         layout.addLayout(row3)
         self._limit_chk.toggled.connect(self._sync_limit_widgets)
         self._sync_limit_widgets()
+        self._sync_force_skip_widgets(False)
 
         row4 = QHBoxLayout()
         scan_btn = QPushButton("Scan & queue jobs")
@@ -179,6 +181,13 @@ class SharpBatchQtWindow(QMainWindow):
 
     def _sync_limit_widgets(self) -> None:
         self._max_edit.setEnabled(self._limit_chk.isChecked())
+
+    @Slot(bool)
+    def _sync_force_skip_widgets(self, _checked: bool) -> None:
+        on = self._force_all_chk.isChecked()
+        if on:
+            self._skip_chk.setChecked(False)
+        self._skip_chk.setEnabled(not on)
 
     def _sync_mirror_widgets(self, _checked: bool) -> None:
         on = self._mirror_chk.isChecked()
@@ -225,7 +234,7 @@ class SharpBatchQtWindow(QMainWindow):
         mx = self._parse_max_splats() if lim else None
         if lim and mx is None:
             mx = 500_000
-        skip = self._skip_chk.isChecked()
+        skip = self._skip_chk.isChecked() and not self._force_all_chk.isChecked()
         mirror = self._mirror_chk.isChecked()
         m_out: Path | None = None
         i_root: Path | None = None

--- a/sharp_local_batch/gui_qt.py
+++ b/sharp_local_batch/gui_qt.py
@@ -336,14 +336,28 @@ class SharpBatchQtWindow(QMainWindow):
             QMessageBox.critical(self, "Apple Photos library", PHOTOS_LIBRARY_MIRROR_HELP)
             return
 
-        jobs = scan_jobs(
+        jobs, total_found = scan_jobs(
             root,
             self._recursive_chk.isChecked(),
             force_all=self._force_all_chk.isChecked(),
             mirror_output_root=mirror_out,
         )
         if not jobs:
-            QMessageBox.information(self, "Scan", "No images need processing (PLY already fresh).")
+            if total_found == 0:
+                QMessageBox.information(
+                    self,
+                    "Scan",
+                    "No supported images were found in the scan folder.\n\n"
+                    "If you use iCloud Photos, originals may not be on disk yet — "
+                    "open a photo in Photos to download it, or enable "
+                    "Photos → Settings → iCloud → Download Originals to this Mac.",
+                )
+            else:
+                QMessageBox.information(
+                    self,
+                    "Scan",
+                    "No images need processing (PLY already up to date).",
+                )
             return
 
         self._snapshot_opts()

--- a/sharp_local_batch/logging_config.py
+++ b/sharp_local_batch/logging_config.py
@@ -1,0 +1,18 @@
+"""One-shot stderr logging for CLI/GUI when the root logger has no handlers."""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+
+def ensure_stderr_info_logging() -> None:
+    """If nothing configured the root logger yet, attach a single INFO StreamHandler."""
+    root = logging.getLogger()
+    if root.handlers:
+        return
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s:%(name)s:%(message)s",
+        stream=sys.stderr,
+    )


### PR DESCRIPTION
## Description

This pull request introduces a new batch processing tool for SHARP splat generation, enabling both GUI and CLI workflows for processing images into PLY files. The batch tool is implemented as a standalone module (`sharp_local_batch`) with support for filesystem watching, job debouncing, and optional PyInstaller packaging for easy distribution. Additionally, the PR refactors shared inference logic out of the main Flask app, improving modularity and code reuse. Documentation is updated to describe these new capabilities.

**Major new features:**

* **Batch Processing Tool (`sharp_local_batch`):**
  - Implements a batch and filesystem-watch tool for generating SHARP splats (PLY files) next to each image, supporting both GUI (Qt/Tkinter) and CLI modes. Provides CLI arguments for folder selection, recursion, forced reprocessing, and splat count limiting. (`sharp_local_batch/__init__.py`, `sharp_local_batch/__main__.py`, `sharp_local_batch/batch_runner.py`, [[1]](diffhunk://#diff-86e5f35950f4c9e58f5df6e1fe52bc0b2a9ed72ce346f09a11e068580a422dc3R1-R3) [[2]](diffhunk://#diff-a21c326bd5ef061a6d2f0ff14c07e9fc263a8a58190b6e6c6d3bf5d52af15477R1-R114) [[3]](diffhunk://#diff-d5998adb9f9d06084f210a53448f8af214d8fb249d7caf493c837948e64d1c29R1-R170)
  - Adds PyInstaller entrypoint and spec file for building a standalone distributable bundle, including dependency handling and resource collection. (`packaging/entry_batch.py`, `packaging/sharp_batch.spec`, [[1]](diffhunk://#diff-30179e72d80acc77af62536b128dd4e9c0c91aa00f385f13dd825913335e431aR1-R16) [[2]](diffhunk://#diff-b59c834a053f52150508686f5347c3e3cd84eb3cf37f51ed77e9ae7e5b5974a9R1-R100)

* **Documentation Updates:**
  - Expands `README.md` to document the new batch tool, usage instructions, CLI options, GUI/CLI fallback logic, and standalone build steps.

**Codebase refactoring and improvements:**

* **Inference Logic Modularization:**
  - Moves core SHARP inference logic (model loading, device selection, PLY utilities, locking) into `sharp_local_batch.core` for reuse by both the Flask app and batch tool, simplifying `app.py` and removing redundant code. (`app.py`, [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L26-L36) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L58-L110) [[3]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L120-L194) [[4]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L263-R147) [[5]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L342-R225) [[6]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L368-R251) [[7]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L384-R275)

**Summary of the most important changes:**

**1. Batch processing and packaging:**
- Introduced `sharp_local_batch` module for batch and watch-based SHARP splat generation, with both GUI and CLI entrypoints. [[1]](diffhunk://#diff-86e5f35950f4c9e58f5df6e1fe52bc0b2a9ed72ce346f09a11e068580a422dc3R1-R3) [[2]](diffhunk://#diff-a21c326bd5ef061a6d2f0ff14c07e9fc263a8a58190b6e6c6d3bf5d52af15477R1-R114) [[3]](diffhunk://#diff-d5998adb9f9d06084f210a53448f8af214d8fb249d7caf493c837948e64d1c29R1-R170)
- Added PyInstaller entrypoint (`entry_batch.py`) and spec (`sharp_batch.spec`) for building a standalone distributable app. [[1]](diffhunk://#diff-30179e72d80acc77af62536b128dd4e9c0c91aa00f385f13dd825913335e431aR1-R16) [[2]](diffhunk://#diff-b59c834a053f52150508686f5347c3e3cd84eb3cf37f51ed77e9ae7e5b5974a9R1-R100)

**2. Documentation:**
- Updated `README.md` with detailed instructions for the batch tool, CLI options, GUI/CLI fallback, and standalone build process.

**3. Core inference logic refactor:**
- Refactored inference, model loading, device selection, and PLY utilities into `sharp_local_batch.core` for shared use, simplifying and de-duplicating `app.py`. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L26-L36) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L58-L110) [[3]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L120-L194) [[4]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L263-R147) [[5]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L342-R225) [[6]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L368-R251) [[7]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L384-R275)