### PR TITLE
Feature/#9 add Niantic spz format support

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,7 +19,6 @@ Or manually:
 
 from __future__ import annotations
 
-import io
 import json
 import logging
 import shutil
@@ -40,6 +39,7 @@ from sharp_local_batch.core import (
     count_ply_vertices,
     decimate_ply_splat_transform,
     ensure_sharp_imports,
+    export_ply_to_spz,
     get_predictor,
     inference_device,
     predictor_loaded,
@@ -100,32 +100,12 @@ def _parse_splat_limit_form() -> tuple[bool, Optional[int], Optional[str]]:
     return True, n, None
 
 
-def _export_sharp_ply_to_spz(ply_path: Path, spz_path: Path) -> bool:
-    """Write Niantic-style .spz from SHARP splat.ply (vertex-only PLY for GaussForge)."""
-    try:
-        import gaussforge
-        from plyfile import PlyData, PlyElement
-    except ImportError:
-        LOGGER.warning(
-            "gaussforge or plyfile not importable; run: pip install -e ./ml-sharp -r requirements.txt"
-        )
-        return False
-    try:
-        plydata = PlyData.read(str(ply_path))
-        vertex_el = plydata["vertex"]
-        minimal = PlyData([PlyElement.describe(vertex_el.data, "vertex")])
-        buf = io.BytesIO()
-        minimal.write(buf)
-        result = gaussforge.GaussForge().convert(buf.getvalue(), "ply", "spz")
-        if "error" in result:
-            LOGGER.warning("SPZ conversion failed: %s", result.get("error"))
-            return False
-        raw = result["data"]
-        spz_path.write_bytes(raw if isinstance(raw, (bytes, bytearray)) else bytes(raw))
+def _parse_export_spz_form() -> bool:
+    """From multipart form: whether SPZ export is requested (default True)."""
+    flag = (request.form.get("export_spz") or "").strip().lower()
+    if not flag:
         return True
-    except Exception:
-        LOGGER.exception("SPZ export failed for %s", ply_path)
-        return False
+    return flag in ("1", "true", "on", "yes")
 
 
 @app.route("/favicon.ico")
@@ -240,6 +220,7 @@ def generate() -> Any:
     limit_on, max_splats, limit_err = _parse_splat_limit_form()
     if limit_err:
         return jsonify({"error": limit_err}), 400
+    do_spz = _parse_export_spz_form()
 
     OUTPUTS_DIR.mkdir(parents=True, exist_ok=True)
     scene_id = str(uuid.uuid4())
@@ -285,7 +266,7 @@ def generate() -> Any:
                 )
 
     spz_path = scene_dir / "splat.spz"
-    has_spz = _export_sharp_ply_to_spz(ply_path, spz_path)
+    has_spz = export_ply_to_spz(ply_path, spz_path) if do_spz else False
 
     meta = {
         "id": scene_id,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 flask>=3.0.0
-gaussforge>=0.5.3
+gaussforge==0.5.5
 plyfile
 watchdog>=4.0.0
 PySide6-Essentials>=6.7.0

--- a/sharp_local_batch/__main__.py
+++ b/sharp_local_batch/__main__.py
@@ -69,12 +69,13 @@ def _cli_main() -> int:
         ),
     )
     p.add_argument(
-        "--remove-ply-after-spz",
-        action="store_true",
+        "--keep-ply",
+        action="store_false",
+        dest="remove_ply_after_spz",
         help=(
-            "After a successful .spz export, delete the .ply file to save space "
-            "(batch only; next run without a PLY will run SHARP again). "
-            "Requires SPZ export (incompatible with --no-export-spz)"
+            "Keep the .ply file after a successful .spz export (by default "
+            "the PLY is deleted to save space; next run without a PLY will "
+            "run SHARP again). Incompatible with --no-export-spz"
         ),
     )
     p.add_argument(
@@ -98,7 +99,7 @@ def _cli_main() -> int:
 
     if args.remove_ply_after_spz and not args.export_spz:
         print(
-            "--remove-ply-after-spz requires SPZ export "
+            "PLY removal requires SPZ export "
             "(do not pass --no-export-spz).",
             file=sys.stderr,
         )

--- a/sharp_local_batch/__main__.py
+++ b/sharp_local_batch/__main__.py
@@ -60,6 +60,24 @@ def _cli_main() -> int:
         help="Skip Niantic .spz export (SPZ is exported by default alongside PLY)",
     )
     p.add_argument(
+        "--spz-only",
+        action="store_true",
+        help=(
+            "SPZ from existing PLY when possible: if a PLY exists, skip SHARP and "
+            "only refresh .spz (optional decimate first). If no PLY yet, run full "
+            "SHARP then .spz. Implies SPZ export (incompatible with --no-export-spz)"
+        ),
+    )
+    p.add_argument(
+        "--remove-ply-after-spz",
+        action="store_true",
+        help=(
+            "After a successful .spz export, delete the .ply file to save space "
+            "(batch only; next run without a PLY will run SHARP again). "
+            "Requires SPZ export (incompatible with --no-export-spz)"
+        ),
+    )
+    p.add_argument(
         "--output-root",
         type=Path,
         default=None,
@@ -69,6 +87,22 @@ def _cli_main() -> int:
         ),
     )
     args = p.parse_args()
+
+    if args.spz_only and not args.export_spz:
+        print(
+            "--spz-only cannot be combined with --no-export-spz "
+            "(SPZ-only mode always exports .spz).",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.remove_ply_after_spz and not args.export_spz:
+        print(
+            "--remove-ply-after-spz requires SPZ export "
+            "(do not pass --no-export-spz).",
+            file=sys.stderr,
+        )
+        return 1
 
     root = args.folder.expanduser().resolve()
     if not root.is_dir():
@@ -94,6 +128,7 @@ def _cli_main() -> int:
         force_all=args.force_all,
         mirror_output_root=mirror_out,
         export_spz=args.export_spz,
+        spz_only=args.spz_only,
     )
     if not jobs:
         if total_found == 0:
@@ -102,7 +137,13 @@ def _cli_main() -> int:
                 file=sys.stderr,
             )
         else:
-            print("No images need processing (PLY already up to date).")
+            if args.spz_only:
+                print(
+                    "No work: every image has .spz up to date with its PLY. "
+                    "Use --force-all to refresh every .spz.",
+                )
+            else:
+                print("No images need processing (PLY already up to date).")
         return 0
 
     max_s = args.max_splats if args.limit_splats else None
@@ -131,6 +172,8 @@ def _cli_main() -> int:
             max_splats=max_s,
             ply_output_path=ply_target,
             export_spz=args.export_spz,
+            spz_only=args.spz_only,
+            remove_ply_after_spz=args.remove_ply_after_spz,
         )
         tag = "ok" if r.ok else "err"
         if r.skipped:

--- a/sharp_local_batch/__main__.py
+++ b/sharp_local_batch/__main__.py
@@ -15,7 +15,7 @@ from sharp_local_batch.core import (
     PHOTOS_LIBRARY_MIRROR_HELP,
     is_photos_library_bundle,
     output_ply_path_for_job,
-    process_image_to_sidecar_ply,
+    update_ply_sidecar,
 )
 
 
@@ -54,6 +54,12 @@ def _cli_main() -> int:
         help="Target splat count when --limit-splats (default 500000)",
     )
     p.add_argument(
+        "--no-export-spz",
+        action="store_false",
+        dest="export_spz",
+        help="Skip Niantic .spz export (SPZ is exported by default alongside PLY)",
+    )
+    p.add_argument(
         "--output-root",
         type=Path,
         default=None,
@@ -87,6 +93,7 @@ def _cli_main() -> int:
         args.recursive,
         force_all=args.force_all,
         mirror_output_root=mirror_out,
+        export_spz=args.export_spz,
     )
     if not jobs:
         if total_found == 0:
@@ -117,11 +124,13 @@ def _cli_main() -> int:
             print(f"    err: {e}", flush=True)
             exit_code = 1
             continue
-        r = process_image_to_sidecar_ply(
+        r = update_ply_sidecar(
             path,
+            skip_up_to_date=not args.force_all,
             limit_splats=args.limit_splats,
             max_splats=max_s,
             ply_output_path=ply_target,
+            export_spz=args.export_spz,
         )
         tag = "ok" if r.ok else "err"
         if r.skipped:

--- a/sharp_local_batch/batch_runner.py
+++ b/sharp_local_batch/batch_runner.py
@@ -30,7 +30,7 @@ def scan_jobs(
     *,
     force_all: bool,
     mirror_output_root: Optional[Path] = None,
-    export_spz: bool = False,
+    export_spz: bool = True,
     spz_only: bool = False,
 ) -> tuple[list[Path], int]:
     """Images under ``root`` that need work (or all images if ``force_all``).
@@ -205,9 +205,9 @@ def worker_loop(
     mirror_output_root: Optional[Path],
     mirror_input_root: Optional[Path],
     on_result: Callable[[PlySidecarResult], None],
-    export_spz: bool = False,
+    export_spz: bool = True,
     spz_only: bool = False,
-    remove_ply_after_spz: bool = False,
+    remove_ply_after_spz: bool = True,
 ) -> None:
     """Drain ``job_q`` until ``None`` sentinel or ``stop_event``."""
     while True:

--- a/sharp_local_batch/batch_runner.py
+++ b/sharp_local_batch/batch_runner.py
@@ -17,6 +17,7 @@ from sharp_local_batch.core import (
     list_image_paths,
     mirrored_ply_path,
     needs_ply_refresh,
+    needs_spz_refresh,
     output_ply_path_for_job,
     sidecar_ply_path,
     update_ply_sidecar,
@@ -30,11 +31,18 @@ def scan_jobs(
     force_all: bool,
     mirror_output_root: Optional[Path] = None,
     export_spz: bool = False,
+    spz_only: bool = False,
 ) -> tuple[list[Path], int]:
     """Images under ``root`` that need work (or all images if ``force_all``).
 
     When ``export_spz`` is set, files whose PLY is current but ``.spz`` sidecar
     is missing are still queued so the worker can top up the SPZ.
+
+    When ``spz_only`` is set (requires ``export_spz``), images **without** a
+    target PLY are still queued so the worker can run the full SHARP pipeline
+    once.  Images that already have a PLY are queued when ``.spz`` is missing,
+    stale vs that PLY, or when ``force_all`` is set.  The worker then converts
+    PLY → SPZ without SHARP only when the PLY already exists.
 
     Returns ``(jobs, total_supported_images)`` where *total_supported_images* is the
     count of supported files found before the PLY-freshness filter — useful to tell
@@ -43,6 +51,37 @@ def scan_jobs(
     scan_root = effective_batch_scan_root(root)
     paths = list_image_paths(scan_root, recursive)
     total = len(paths)
+    effective_spz_only = bool(spz_only and export_spz)
+
+    if effective_spz_only:
+        root_r = root.resolve()
+        if mirror_output_root is None:
+
+            def _spz_only_need(p: Path) -> bool:
+                ply = sidecar_ply_path(p)
+                if not ply.is_file():
+                    return True
+                if force_all:
+                    return True
+                return needs_spz_refresh(ply)
+
+            return [p for p in paths if _spz_only_need(p)], total
+
+        out_r = mirror_output_root.resolve()
+
+        def _spz_only_need_m(p: Path) -> bool:
+            try:
+                target = mirrored_ply_path(p, root_r, out_r)
+            except ValueError:
+                return True
+            if not target.is_file():
+                return True
+            if force_all:
+                return True
+            return needs_spz_refresh(target)
+
+        return [p for p in paths if _spz_only_need_m(p)], total
+
     if force_all:
         return paths, total
     root_r = root.resolve()
@@ -167,6 +206,8 @@ def worker_loop(
     mirror_input_root: Optional[Path],
     on_result: Callable[[PlySidecarResult], None],
     export_spz: bool = False,
+    spz_only: bool = False,
+    remove_ply_after_spz: bool = False,
 ) -> None:
     """Drain ``job_q`` until ``None`` sentinel or ``stop_event``."""
     while True:
@@ -210,5 +251,7 @@ def worker_loop(
                 max_splats=max_splats,
                 ply_output_path=ply_target,
                 export_spz=export_spz,
+                spz_only=spz_only,
+                remove_ply_after_spz=remove_ply_after_spz,
             )
         )

--- a/sharp_local_batch/batch_runner.py
+++ b/sharp_local_batch/batch_runner.py
@@ -18,8 +18,8 @@ from sharp_local_batch.core import (
     mirrored_ply_path,
     needs_ply_refresh,
     output_ply_path_for_job,
-    process_image_to_sidecar_ply,
     sidecar_ply_path,
+    update_ply_sidecar,
 )
 
 
@@ -29,8 +29,12 @@ def scan_jobs(
     *,
     force_all: bool,
     mirror_output_root: Optional[Path] = None,
+    export_spz: bool = False,
 ) -> tuple[list[Path], int]:
     """Images under ``root`` that need work (or all images if ``force_all``).
+
+    When ``export_spz`` is set, files whose PLY is current but ``.spz`` sidecar
+    is missing are still queued so the worker can top up the SPZ.
 
     Returns ``(jobs, total_supported_images)`` where *total_supported_images* is the
     count of supported files found before the PLY-freshness filter — useful to tell
@@ -43,7 +47,9 @@ def scan_jobs(
         return paths, total
     root_r = root.resolve()
     if mirror_output_root is None:
-        return [p for p in paths if needs_ply_refresh(p)], total
+        return [
+            p for p in paths if needs_ply_refresh(p, require_spz=export_spz)
+        ], total
     out_r = mirror_output_root.resolve()
 
     def _needs_work(p: Path) -> bool:
@@ -51,7 +57,7 @@ def scan_jobs(
             target = mirrored_ply_path(p, root_r, out_r)
         except ValueError:
             return True
-        return needs_ply_refresh(p, target)
+        return needs_ply_refresh(p, target, require_spz=export_spz)
 
     return [p for p in paths if _needs_work(p)], total
 
@@ -160,6 +166,7 @@ def worker_loop(
     mirror_output_root: Optional[Path],
     mirror_input_root: Optional[Path],
     on_result: Callable[[PlySidecarResult], None],
+    export_spz: bool = False,
 ) -> None:
     """Drain ``job_q`` until ``None`` sentinel or ``stop_event``."""
     while True:
@@ -195,22 +202,13 @@ def worker_loop(
                 )
             )
             continue
-        if skip_up_to_date and not needs_ply_refresh(image_path, ply_target):
-            on_result(
-                PlySidecarResult(
-                    ok=True,
-                    image_path=image_path,
-                    ply_path=ply_target,
-                    message="Skipped (PLY up to date)",
-                    skipped=True,
-                )
-            )
-            continue
         on_result(
-            process_image_to_sidecar_ply(
+            update_ply_sidecar(
                 image_path,
+                skip_up_to_date=skip_up_to_date,
                 limit_splats=limit_splats,
                 max_splats=max_splats,
                 ply_output_path=ply_target,
+                export_spz=export_spz,
             )
         )

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -192,6 +192,29 @@ def export_ply_to_spz(ply_path: Path, spz_path: Path) -> bool:
         return False
 
 
+def try_remove_ply_after_spz(
+    ply_path: Path,
+    spz_path: Optional[Path],
+    *,
+    remove_requested: bool,
+) -> tuple[bool, Optional[str]]:
+    """Delete ``ply_path`` after a successful SPZ export when ``remove_requested``.
+
+    Returns ``(removed, note)`` where *note* is a short user-facing reason if
+    removal was requested but the PLY was left on disk; otherwise ``None``.
+    """
+    if not remove_requested or spz_path is None:
+        return False, None
+    if not spz_path.is_file():
+        return False, "PLY kept (.spz missing after export)"
+    try:
+        ply_path.unlink()
+        return True, None
+    except OSError as e:
+        LOGGER.warning("Could not remove PLY after SPZ: %s", e)
+        return False, f"PLY kept (could not remove: {e})"
+
+
 @functools.lru_cache(maxsize=1)
 def supported_image_suffixes() -> frozenset[str]:
     ensure_sharp_imports()
@@ -360,6 +383,22 @@ def needs_ply_refresh(
     return False
 
 
+def needs_spz_refresh(ply_path: Path) -> bool:
+    """True when ``ply_path`` exists and the ``.spz`` sidecar is missing or stale.
+
+    Stale means the SPZ file is older than the PLY (e.g. PLY was regenerated).
+    """
+    if not ply_path.is_file():
+        return False
+    spz_path = ply_path.with_suffix(".spz")
+    if not spz_path.is_file():
+        return True
+    try:
+        return spz_path.stat().st_mtime < ply_path.stat().st_mtime
+    except OSError:
+        return True
+
+
 @dataclass
 class PlySidecarResult:
     ok: bool
@@ -373,6 +412,7 @@ class PlySidecarResult:
     skipped: bool = False
     spz_path: Optional[Path] = None
     spz_error: Optional[str] = None
+    ply_removed: bool = False
 
 
 def process_image_to_sidecar_ply(
@@ -382,6 +422,7 @@ def process_image_to_sidecar_ply(
     max_splats: Optional[int] = None,
     ply_output_path: Optional[Path] = None,
     export_spz: bool = False,
+    remove_ply_after_spz: bool = False,
 ) -> PlySidecarResult:
     """Run SHARP on ``image_path`` and write PLY beside it or at ``ply_output_path``; optional decimate + SPZ."""
     image_path = image_path.resolve()
@@ -467,6 +508,16 @@ def process_image_to_sidecar_ply(
     elif spz_error:
         msg += f"; {spz_error}"
 
+    ply_removed = False
+    if remove_ply_after_spz and export_spz and spz_path is not None:
+        ply_removed, note = try_remove_ply_after_spz(
+            ply_path, spz_path, remove_requested=True
+        )
+        if note:
+            msg += f"; {note}"
+        elif ply_removed:
+            msg += "; PLY removed (only .spz kept)"
+
     return PlySidecarResult(
         ok=True,
         image_path=image_path,
@@ -478,6 +529,7 @@ def process_image_to_sidecar_ply(
         decimate_error=decimate_error,
         spz_path=spz_path,
         spz_error=spz_error,
+        ply_removed=ply_removed,
     )
 
 
@@ -489,14 +541,26 @@ def update_ply_sidecar(
     max_splats: Optional[int] = None,
     ply_output_path: Optional[Path] = None,
     export_spz: bool = False,
+    spz_only: bool = False,
+    remove_ply_after_spz: bool = False,
 ) -> PlySidecarResult:
-    """Skip, top up missing SPZ, or run the full pipeline.
+    """Skip, top up missing SPZ, SPZ-only from existing PLY, or run the full pipeline.
 
     When ``skip_up_to_date`` is set and the PLY is already current, this
     avoids re-running inference: if ``export_spz`` is on but the ``.spz``
     sidecar is missing, only the SPZ conversion runs against the existing
     PLY; otherwise the file is reported as skipped.  In all other cases the
     full :func:`process_image_to_sidecar_ply` pipeline runs.
+
+    When ``spz_only`` is set (with ``export_spz``) and a PLY already exists at
+    the target path, SHARP is not run: optional ``limit_splats`` /
+    ``max_splats`` runs ``decimate_ply_splat_transform`` on that file, then
+    ``export_ply_to_spz``.  If there is **no** PLY yet, this falls back to the
+    full :func:`process_image_to_sidecar_ply` pipeline (inference, optional
+    decimate, SPZ) so a first-time folder still works.
+
+    When ``remove_ply_after_spz`` is set, the target ``.ply`` is deleted after a
+    successful ``.spz`` write (batch use; keeps disk usage down).
     """
     image_path = image_path.resolve()
     ply_path = (
@@ -504,6 +568,122 @@ def update_ply_sidecar(
         if ply_output_path is None
         else ply_output_path.resolve()
     )
+
+    if spz_only:
+        if not export_spz:
+            return PlySidecarResult(
+                ok=False,
+                image_path=image_path,
+                ply_path=ply_path,
+                message="SPZ-only mode requires Export SPZ to be enabled",
+            )
+        if not ply_path.is_file():
+            return process_image_to_sidecar_ply(
+                image_path,
+                limit_splats=limit_splats,
+                max_splats=max_splats,
+                ply_output_path=ply_path,
+                export_spz=export_spz,
+                remove_ply_after_spz=remove_ply_after_spz,
+            )
+        if limit_splats and max_splats is not None and max_splats < 1:
+            return PlySidecarResult(
+                ok=False,
+                image_path=image_path,
+                ply_path=ply_path,
+                message="max_splats must be at least 1",
+            )
+
+        spz_target = ply_path.with_suffix(".spz")
+        if skip_up_to_date and spz_target.is_file():
+            try:
+                if spz_target.stat().st_mtime >= ply_path.stat().st_mtime:
+                    return PlySidecarResult(
+                        ok=True,
+                        image_path=image_path,
+                        ply_path=ply_path,
+                        message="Skipped (SPZ up to date with PLY)",
+                        skipped=True,
+                    )
+            except OSError:
+                pass
+
+        splat_count_full: Optional[int] = None
+        try:
+            splat_count_full = count_ply_vertices(ply_path)
+        except (OSError, ValueError):
+            pass
+
+        splat_count = splat_count_full
+        limit_applied = False
+        decimate_error: Optional[str] = None
+
+        if (
+            limit_splats
+            and max_splats is not None
+            and splat_count_full is not None
+            and splat_count_full > max_splats
+        ):
+            if decimate_ply_splat_transform(ply_path, max_splats):
+                splat_count = count_ply_vertices(ply_path)
+                limit_applied = (
+                    splat_count is not None and splat_count < splat_count_full
+                )
+            else:
+                decimate_error = (
+                    "Decimation failed or splat-transform missing; "
+                    "install: npm install -g @playcanvas/splat-transform"
+                )
+
+        if export_ply_to_spz(ply_path, spz_target):
+            try:
+                count = count_ply_vertices(ply_path)
+            except (OSError, ValueError):
+                count = splat_count
+            msg = "SPZ exported (existing PLY only)"
+            if count is not None:
+                msg += f" — {count:,} splats"
+            if limit_applied and splat_count_full is not None and count is not None:
+                if splat_count_full > count:
+                    msg += f" (from {splat_count_full:,})"
+            if decimate_error:
+                msg += f"; {decimate_error}"
+            ply_removed = False
+            if remove_ply_after_spz:
+                ply_removed, note = try_remove_ply_after_spz(
+                    ply_path, spz_target, remove_requested=True
+                )
+                if note:
+                    msg += f"; {note}"
+                elif ply_removed:
+                    msg += "; PLY removed (only .spz kept)"
+            return PlySidecarResult(
+                ok=True,
+                image_path=image_path,
+                ply_path=ply_path,
+                message=msg,
+                splat_count=count,
+                splat_count_full=splat_count_full if splat_count_full is not None else count,
+                limit_applied=limit_applied,
+                decimate_error=decimate_error,
+                spz_path=spz_target,
+                ply_removed=ply_removed,
+            )
+        err = "SPZ export failed (gaussforge missing or conversion error)"
+        fail_msg = err
+        if decimate_error:
+            fail_msg = f"{err}; {decimate_error}"
+        return PlySidecarResult(
+            ok=False,
+            image_path=image_path,
+            ply_path=ply_path,
+            message=fail_msg,
+            splat_count=splat_count,
+            splat_count_full=splat_count_full,
+            limit_applied=limit_applied,
+            decimate_error=decimate_error,
+            spz_error=err,
+        )
 
     if skip_up_to_date and ply_path.is_file():
         try:
@@ -521,6 +701,15 @@ def update_ply_sidecar(
                     msg = "SPZ exported (PLY current)"
                     if count is not None:
                         msg += f" — {count:,} splats"
+                    ply_removed = False
+                    if remove_ply_after_spz:
+                        ply_removed, note = try_remove_ply_after_spz(
+                            ply_path, spz_target, remove_requested=True
+                        )
+                        if note:
+                            msg += f"; {note}"
+                        elif ply_removed:
+                            msg += "; PLY removed (only .spz kept)"
                     return PlySidecarResult(
                         ok=True,
                         image_path=image_path,
@@ -529,6 +718,7 @@ def update_ply_sidecar(
                         splat_count=count,
                         splat_count_full=count,
                         spz_path=spz_target,
+                        ply_removed=ply_removed,
                     )
                 err = "SPZ export failed (gaussforge missing or conversion error)"
                 return PlySidecarResult(
@@ -552,4 +742,5 @@ def update_ply_sidecar(
         max_splats=max_splats,
         ply_output_path=ply_path,
         export_spz=export_spz,
+        remove_ply_after_spz=remove_ply_after_spz,
     )

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -421,8 +421,8 @@ def process_image_to_sidecar_ply(
     limit_splats: bool = False,
     max_splats: Optional[int] = None,
     ply_output_path: Optional[Path] = None,
-    export_spz: bool = False,
-    remove_ply_after_spz: bool = False,
+    export_spz: bool = True,
+    remove_ply_after_spz: bool = True,
 ) -> PlySidecarResult:
     """Run SHARP on ``image_path`` and write PLY beside it or at ``ply_output_path``; optional decimate + SPZ."""
     image_path = image_path.resolve()
@@ -540,9 +540,9 @@ def update_ply_sidecar(
     limit_splats: bool = False,
     max_splats: Optional[int] = None,
     ply_output_path: Optional[Path] = None,
-    export_spz: bool = False,
+    export_spz: bool = True,
     spz_only: bool = False,
-    remove_ply_after_spz: bool = False,
+    remove_ply_after_spz: bool = True,
 ) -> PlySidecarResult:
     """Skip, top up missing SPZ, SPZ-only from existing PLY, or run the full pipeline.
 

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import io
 import logging
 import os
 import shutil
@@ -158,6 +159,39 @@ def decimate_ply_splat_transform(
         return False
 
 
+def export_ply_to_spz(ply_path: Path, spz_path: Path) -> bool:
+    """Write Niantic .spz from a SHARP splat PLY (vertex-only PLY for GaussForge).
+
+    Returns ``True`` on success.  Logs a warning and returns ``False`` when
+    ``gaussforge`` / ``plyfile`` is not importable or conversion fails.
+    """
+    try:
+        import gaussforge
+        from plyfile import PlyData, PlyElement
+    except ImportError:
+        LOGGER.warning(
+            "gaussforge or plyfile not importable; run: pip install gaussforge plyfile"
+        )
+        return False
+    try:
+        plydata = PlyData.read(str(ply_path))
+        vertex_el = plydata["vertex"]
+        minimal = PlyData([PlyElement.describe(vertex_el.data, "vertex")])
+        buf = io.BytesIO()
+        minimal.write(buf)
+        result = gaussforge.GaussForge().convert(buf.getvalue(), "ply", "spz")
+        if "error" in result:
+            LOGGER.warning("SPZ conversion failed: %s", result.get("error"))
+            return False
+        raw = result["data"]
+        spz_path.parent.mkdir(parents=True, exist_ok=True)
+        spz_path.write_bytes(raw if isinstance(raw, (bytes, bytearray)) else bytes(raw))
+        return True
+    except Exception:
+        LOGGER.exception("SPZ export failed for %s", ply_path)
+        return False
+
+
 @functools.lru_cache(maxsize=1)
 def supported_image_suffixes() -> frozenset[str]:
     ensure_sharp_imports()
@@ -306,14 +340,24 @@ def output_ply_path_for_job(
     return mirrored_ply_path(img, mirror_input_root, mirror_output_root)
 
 
-def needs_ply_refresh(image_path: Path, ply_path: Optional[Path] = None) -> bool:
+def needs_ply_refresh(
+    image_path: Path,
+    ply_path: Optional[Path] = None,
+    *,
+    require_spz: bool = False,
+) -> bool:
+    """True if the PLY (and optionally the .spz sidecar) needs (re)generating."""
     ply = sidecar_ply_path(image_path) if ply_path is None else ply_path
     if not ply.is_file():
         return True
     try:
-        return image_path.stat().st_mtime > ply.stat().st_mtime
+        if image_path.stat().st_mtime > ply.stat().st_mtime:
+            return True
     except OSError:
         return True
+    if require_spz and not ply.with_suffix(".spz").is_file():
+        return True
+    return False
 
 
 @dataclass
@@ -327,6 +371,8 @@ class PlySidecarResult:
     limit_applied: bool = False
     decimate_error: Optional[str] = None
     skipped: bool = False
+    spz_path: Optional[Path] = None
+    spz_error: Optional[str] = None
 
 
 def process_image_to_sidecar_ply(
@@ -335,8 +381,9 @@ def process_image_to_sidecar_ply(
     limit_splats: bool = False,
     max_splats: Optional[int] = None,
     ply_output_path: Optional[Path] = None,
+    export_spz: bool = False,
 ) -> PlySidecarResult:
-    """Run SHARP on ``image_path`` and write PLY beside it or at ``ply_output_path``; optional decimate."""
+    """Run SHARP on ``image_path`` and write PLY beside it or at ``ply_output_path``; optional decimate + SPZ."""
     image_path = image_path.resolve()
     ply_path = sidecar_ply_path(image_path) if ply_output_path is None else ply_output_path.resolve()
 
@@ -401,11 +448,24 @@ def process_image_to_sidecar_ply(
                 "install: npm install -g @playcanvas/splat-transform"
             )
 
+    spz_path: Optional[Path] = None
+    spz_error: Optional[str] = None
+    if export_spz:
+        spz_target = ply_path.with_suffix(".spz")
+        if export_ply_to_spz(ply_path, spz_target):
+            spz_path = spz_target
+        else:
+            spz_error = "SPZ export failed (gaussforge missing or conversion error)"
+
     msg = f"OK — {splat_count:,} splats"
     if limit_applied and splat_count_full > splat_count:
         msg += f" (from {splat_count_full:,})"
     if decimate_error:
         msg += f"; {decimate_error}"
+    if spz_path:
+        msg += "; SPZ exported"
+    elif spz_error:
+        msg += f"; {spz_error}"
 
     return PlySidecarResult(
         ok=True,
@@ -416,4 +476,80 @@ def process_image_to_sidecar_ply(
         splat_count_full=splat_count_full,
         limit_applied=limit_applied,
         decimate_error=decimate_error,
+        spz_path=spz_path,
+        spz_error=spz_error,
+    )
+
+
+def update_ply_sidecar(
+    image_path: Path,
+    *,
+    skip_up_to_date: bool,
+    limit_splats: bool = False,
+    max_splats: Optional[int] = None,
+    ply_output_path: Optional[Path] = None,
+    export_spz: bool = False,
+) -> PlySidecarResult:
+    """Skip, top up missing SPZ, or run the full pipeline.
+
+    When ``skip_up_to_date`` is set and the PLY is already current, this
+    avoids re-running inference: if ``export_spz`` is on but the ``.spz``
+    sidecar is missing, only the SPZ conversion runs against the existing
+    PLY; otherwise the file is reported as skipped.  In all other cases the
+    full :func:`process_image_to_sidecar_ply` pipeline runs.
+    """
+    image_path = image_path.resolve()
+    ply_path = (
+        sidecar_ply_path(image_path)
+        if ply_output_path is None
+        else ply_output_path.resolve()
+    )
+
+    if skip_up_to_date and ply_path.is_file():
+        try:
+            ply_stale = image_path.stat().st_mtime > ply_path.stat().st_mtime
+        except OSError:
+            ply_stale = True
+        if not ply_stale:
+            spz_target = ply_path.with_suffix(".spz")
+            if export_spz and not spz_target.is_file():
+                if export_ply_to_spz(ply_path, spz_target):
+                    try:
+                        count = count_ply_vertices(ply_path)
+                    except (OSError, ValueError):
+                        count = None
+                    msg = "SPZ exported (PLY current)"
+                    if count is not None:
+                        msg += f" — {count:,} splats"
+                    return PlySidecarResult(
+                        ok=True,
+                        image_path=image_path,
+                        ply_path=ply_path,
+                        message=msg,
+                        splat_count=count,
+                        splat_count_full=count,
+                        spz_path=spz_target,
+                    )
+                err = "SPZ export failed (gaussforge missing or conversion error)"
+                return PlySidecarResult(
+                    ok=False,
+                    image_path=image_path,
+                    ply_path=ply_path,
+                    message=err,
+                    spz_error=err,
+                )
+            return PlySidecarResult(
+                ok=True,
+                image_path=image_path,
+                ply_path=ply_path,
+                message="Skipped (PLY up to date)",
+                skipped=True,
+            )
+
+    return process_image_to_sidecar_ply(
+        image_path,
+        limit_splats=limit_splats,
+        max_splats=max_splats,
+        ply_output_path=ply_path,
+        export_spz=export_spz,
     )

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -378,7 +378,7 @@ def needs_ply_refresh(
             return True
     except OSError:
         return True
-    if require_spz and not ply.with_suffix(".spz").is_file():
+    if require_spz and needs_spz_refresh(ply):
         return True
     return False
 
@@ -692,7 +692,7 @@ def update_ply_sidecar(
             ply_stale = True
         if not ply_stale:
             spz_target = ply_path.with_suffix(".spz")
-            if export_spz and not spz_target.is_file():
+            if export_spz and needs_spz_refresh(ply_path):
                 if export_ply_to_spz(ply_path, spz_target):
                     try:
                         count = count_ply_vertices(ply_path)

--- a/sharp_local_batch/gui.py
+++ b/sharp_local_batch/gui.py
@@ -26,7 +26,7 @@ class SharpBatchGui:
     def __init__(self) -> None:
         self.root = tk.Tk()
         self.root.title("sharp_local_batch")
-        self.root.minsize(520, 420)
+        self.root.minsize(640, 440)
 
         self._folder_var = tk.StringVar(value="")
         self._recursive_var = tk.BooleanVar(value=True)
@@ -35,6 +35,8 @@ class SharpBatchGui:
         self._max_splats_var = tk.StringVar(value="500000")
         self._skip_up_to_date_var = tk.BooleanVar(value=True)
         self._spz_var = tk.BooleanVar(value=True)
+        self._spz_only_var = tk.BooleanVar(value=False)
+        self._remove_ply_after_spz_var = tk.BooleanVar(value=False)
         self._watch_var = tk.BooleanVar(value=False)
         self._mirror_var = tk.BooleanVar(value=False)
         self._output_mirror_var = tk.StringVar(value="")
@@ -47,6 +49,8 @@ class SharpBatchGui:
         self._snap_max: int | None = None
         self._snap_skip = True
         self._snap_spz = True
+        self._snap_spz_only = False
+        self._snap_remove_ply_after_spz = False
         self._snap_mirror_output: Path | None = None
         self._snap_input_root: Path | None = None
         self._scan_running = False
@@ -146,25 +150,44 @@ class SharpBatchGui:
 
         row3 = ttk.Frame(root_f)
         row3.pack(fill=tk.X, **pad)
-        ttk.Checkbutton(row3, text="Limit splat count", variable=self._limit_var).pack(
-            side=tk.LEFT
+        self._limit_cb = ttk.Checkbutton(
+            row3, text="Limit splat count", variable=self._limit_var
         )
+        self._limit_cb.pack(side=tk.LEFT)
         ttk.Label(row3, text="Max splats").pack(side=tk.LEFT, padx=(8, 4))
-        self._max_entry = ttk.Entry(row3, textvariable=self._max_splats_var, width=12)
-        self._max_entry.pack(side=tk.LEFT)
+        self._max_entry = ttk.Entry(row3, textvariable=self._max_splats_var, width=14)
+        self._max_entry.pack(side=tk.LEFT, padx=(0, 8))
         self._skip_cb = ttk.Checkbutton(
             row3,
             text="Skip up-to-date PLY",
             variable=self._skip_up_to_date_var,
         )
-        self._skip_cb.pack(side=tk.LEFT, padx=(16, 0))
-        ttk.Checkbutton(row3, text="Export SPZ", variable=self._spz_var).pack(
-            side=tk.LEFT, padx=(16, 0)
-        )
+        self._skip_cb.pack(side=tk.LEFT, padx=(8, 0))
 
+        row3b = ttk.Frame(root_f)
+        row3b.pack(fill=tk.X, **pad)
+        self._spz_cb = ttk.Checkbutton(row3b, text="Export SPZ", variable=self._spz_var)
+        self._spz_cb.pack(side=tk.LEFT)
+        self._spz_only_cb = ttk.Checkbutton(
+            row3b,
+            text="SPZ from existing PLY only (no new render)",
+            variable=self._spz_only_var,
+            command=self._on_spz_only_toggle,
+        )
+        self._spz_only_cb.pack(side=tk.LEFT, padx=(16, 0))
+        self._remove_ply_cb = ttk.Checkbutton(
+            row3b,
+            text="Remove PLY after successful SPZ",
+            variable=self._remove_ply_after_spz_var,
+        )
+        self._remove_ply_cb.pack(side=tk.LEFT, padx=(16, 0))
+
+        self._spz_var.trace_add("write", lambda *_: self._sync_remove_ply_widgets())
         self._limit_var.trace_add("write", lambda *_: self._sync_limit_widgets())
         self._sync_limit_widgets()
         self._sync_force_skip_widgets()
+        self._on_spz_only_toggle()
+        self._sync_remove_ply_widgets()
 
         row4 = ttk.Frame(root_f)
         row4.pack(fill=tk.X, **pad)
@@ -201,13 +224,29 @@ class SharpBatchGui:
             "under the target folder for mirror. Optional cap uses splat-transform "
             "(npm i -g @playcanvas/splat-transform)."
         )
-        ttk.Label(root_f, text=hint, wraplength=500, foreground="#666").pack(
+        ttk.Label(root_f, text=hint, wraplength=620, foreground="#666").pack(
             fill=tk.X, **pad
         )
 
     def _sync_limit_widgets(self) -> None:
         on = self._limit_var.get()
         self._max_entry.configure(state=tk.NORMAL if on else "disabled")
+
+    def _on_spz_only_toggle(self) -> None:
+        if self._spz_only_var.get():
+            self._spz_var.set(True)
+            self._spz_cb.state(["disabled"])
+        else:
+            self._spz_cb.state(["!disabled"])
+        self._sync_limit_widgets()
+        self._sync_remove_ply_widgets()
+
+    def _sync_remove_ply_widgets(self) -> None:
+        if self._spz_var.get():
+            self._remove_ply_cb.state(["!disabled"])
+        else:
+            self._remove_ply_after_spz_var.set(False)
+            self._remove_ply_cb.state(["disabled"])
 
     def _sync_force_skip_widgets(self) -> None:
         if self._force_all_var.get():
@@ -270,11 +309,15 @@ class SharpBatchGui:
                 if fr:
                     i_root = Path(fr).expanduser().resolve()
         spz = self._spz_var.get()
+        spz_only = self._spz_only_var.get()
+        rm_ply = self._remove_ply_after_spz_var.get()
         with self._opts_lock:
             self._snap_lim = bool(lim)
             self._snap_max = mx if lim else None
             self._snap_skip = skip
             self._snap_spz = spz
+            self._snap_spz_only = spz_only
+            self._snap_remove_ply_after_spz = rm_ply
             self._snap_mirror_output = m_out
             self._snap_input_root = i_root
 
@@ -352,6 +395,7 @@ class SharpBatchGui:
             force_all=self._force_all_var.get(),
             mirror_output_root=mirror_out,
             export_spz=self._spz_var.get(),
+            spz_only=self._spz_only_var.get(),
         )
         if not jobs:
             if total_found == 0:
@@ -363,10 +407,18 @@ class SharpBatchGui:
                     "Photos → Settings → iCloud → Download Originals to this Mac.",
                 )
             else:
-                messagebox.showinfo(
-                    "Scan",
-                    "No images need processing (PLY already up to date).",
-                )
+                if self._spz_only_var.get() and self._spz_var.get():
+                    messagebox.showinfo(
+                        "Scan",
+                        "No work found: every image already has an .spz that is up "
+                        "to date with its PLY. Turn on Reprocess all to refresh .spz "
+                        "files anyway.",
+                    )
+                else:
+                    messagebox.showinfo(
+                        "Scan",
+                        "No images need processing (PLY already up to date).",
+                    )
             return
 
         self._snapshot_opts()
@@ -500,6 +552,8 @@ class SharpBatchGui:
                 max_s = self._snap_max
                 skip = self._snap_skip
                 spz = self._snap_spz
+                spz_only = self._snap_spz_only
+                rm_ply = self._snap_remove_ply_after_spz
                 m_out = self._snap_mirror_output
                 i_root = self._snap_input_root
 
@@ -526,6 +580,8 @@ class SharpBatchGui:
                 max_splats=max_s if lim else None,
                 ply_output_path=ply_target,
                 export_spz=spz,
+                spz_only=spz_only,
+                remove_ply_after_spz=rm_ply,
             )
 
             self._safe_after(0, self._on_job_done, r)

--- a/sharp_local_batch/gui.py
+++ b/sharp_local_batch/gui.py
@@ -36,7 +36,7 @@ class SharpBatchGui:
         self._skip_up_to_date_var = tk.BooleanVar(value=True)
         self._spz_var = tk.BooleanVar(value=True)
         self._spz_only_var = tk.BooleanVar(value=False)
-        self._remove_ply_after_spz_var = tk.BooleanVar(value=False)
+        self._remove_ply_after_spz_var = tk.BooleanVar(value=True)
         self._watch_var = tk.BooleanVar(value=False)
         self._mirror_var = tk.BooleanVar(value=False)
         self._output_mirror_var = tk.StringVar(value="")

--- a/sharp_local_batch/gui.py
+++ b/sharp_local_batch/gui.py
@@ -16,10 +16,9 @@ from sharp_local_batch.core import (
     PlySidecarResult,
     default_macos_photos_library_path,
     is_photos_library_bundle,
-    needs_ply_refresh,
     output_ply_path_for_job,
-    process_image_to_sidecar_ply,
     sidecar_ply_path,
+    update_ply_sidecar,
 )
 
 
@@ -35,6 +34,7 @@ class SharpBatchGui:
         self._limit_var = tk.BooleanVar(value=False)
         self._max_splats_var = tk.StringVar(value="500000")
         self._skip_up_to_date_var = tk.BooleanVar(value=True)
+        self._spz_var = tk.BooleanVar(value=True)
         self._watch_var = tk.BooleanVar(value=False)
         self._mirror_var = tk.BooleanVar(value=False)
         self._output_mirror_var = tk.StringVar(value="")
@@ -46,6 +46,7 @@ class SharpBatchGui:
         self._snap_lim = False
         self._snap_max: int | None = None
         self._snap_skip = True
+        self._snap_spz = True
         self._snap_mirror_output: Path | None = None
         self._snap_input_root: Path | None = None
         self._scan_running = False
@@ -157,6 +158,9 @@ class SharpBatchGui:
             variable=self._skip_up_to_date_var,
         )
         self._skip_cb.pack(side=tk.LEFT, padx=(16, 0))
+        ttk.Checkbutton(row3, text="Export SPZ", variable=self._spz_var).pack(
+            side=tk.LEFT, padx=(16, 0)
+        )
 
         self._limit_var.trace_add("write", lambda *_: self._sync_limit_widgets())
         self._sync_limit_widgets()
@@ -265,10 +269,12 @@ class SharpBatchGui:
                 fr = self._folder_var.get().strip()
                 if fr:
                     i_root = Path(fr).expanduser().resolve()
+        spz = self._spz_var.get()
         with self._opts_lock:
             self._snap_lim = bool(lim)
             self._snap_max = mx if lim else None
             self._snap_skip = skip
+            self._snap_spz = spz
             self._snap_mirror_output = m_out
             self._snap_input_root = i_root
 
@@ -345,6 +351,7 @@ class SharpBatchGui:
             self._recursive_var.get(),
             force_all=self._force_all_var.get(),
             mirror_output_root=mirror_out,
+            export_spz=self._spz_var.get(),
         )
         if not jobs:
             if total_found == 0:
@@ -492,6 +499,7 @@ class SharpBatchGui:
                 lim = self._snap_lim
                 max_s = self._snap_max
                 skip = self._snap_skip
+                spz = self._snap_spz
                 m_out = self._snap_mirror_output
                 i_root = self._snap_input_root
 
@@ -511,21 +519,14 @@ class SharpBatchGui:
                 self._safe_after(0, self._on_job_done, r)
                 continue
 
-            if skip and not needs_ply_refresh(p, ply_target):
-                r = PlySidecarResult(
-                    ok=True,
-                    image_path=p,
-                    ply_path=ply_target,
-                    message="Skipped (PLY up to date)",
-                    skipped=True,
-                )
-            else:
-                r = process_image_to_sidecar_ply(
-                    p,
-                    limit_splats=lim,
-                    max_splats=max_s if lim else None,
-                    ply_output_path=ply_target,
-                )
+            r = update_ply_sidecar(
+                p,
+                skip_up_to_date=skip,
+                limit_splats=lim,
+                max_splats=max_s if lim else None,
+                ply_output_path=ply_target,
+                export_spz=spz,
+            )
 
             self._safe_after(0, self._on_job_done, r)
 

--- a/sharp_local_batch/gui_qt.py
+++ b/sharp_local_batch/gui_qt.py
@@ -159,6 +159,7 @@ class SharpBatchQtWindow(QMainWindow):
         )
         row3b.addWidget(self._spz_only_chk)
         self._remove_ply_chk = QCheckBox("Remove PLY after successful SPZ")
+        self._remove_ply_chk.setChecked(True)
         self._remove_ply_chk.setToolTip(
             "Deletes the .ply only after .spz is written successfully. "
             "The web preview tool is unchanged; batch only. "

--- a/sharp_local_batch/gui_qt.py
+++ b/sharp_local_batch/gui_qt.py
@@ -49,7 +49,7 @@ class SharpBatchQtWindow(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("sharp_local_batch")
-        self.resize(580, 520)
+        self.resize(720, 540)
 
         self._job_q: queue.Queue[Path] = queue.Queue()
         self._quit_app = threading.Event()
@@ -58,6 +58,8 @@ class SharpBatchQtWindow(QMainWindow):
         self._snap_max: int | None = None
         self._snap_skip = True
         self._snap_spz = True
+        self._snap_spz_only = False
+        self._snap_remove_ply_after_spz = False
         self._batch_total = 0
         self._batch_done = 0
         self._watch: WatchController | None = None
@@ -136,19 +138,42 @@ class SharpBatchQtWindow(QMainWindow):
         row3.addWidget(self._limit_chk)
         row3.addWidget(QLabel("Max splats"))
         self._max_edit = QLineEdit("500000")
-        self._max_edit.setMaximumWidth(120)
+        self._max_edit.setMinimumWidth(120)
+        self._max_edit.setFixedWidth(132)
         row3.addWidget(self._max_edit)
         self._skip_chk = QCheckBox("Skip up-to-date PLY")
         self._skip_chk.setChecked(True)
         row3.addWidget(self._skip_chk)
-        self._spz_chk = QCheckBox("Export SPZ")
-        self._spz_chk.setChecked(True)
-        row3.addWidget(self._spz_chk)
         row3.addStretch()
         layout.addLayout(row3)
+
+        row3b = QHBoxLayout()
+        self._spz_chk = QCheckBox("Export SPZ")
+        self._spz_chk.setChecked(True)
+        row3b.addWidget(self._spz_chk)
+        self._spz_only_chk = QCheckBox("SPZ from existing PLY only (no new render)")
+        self._spz_only_chk.setToolTip(
+            "When a PLY already exists: no SHARP — optional Limit splat count runs "
+            "splat-transform on that PLY, then .spz is written. "
+            "When no PLY yet: runs full SHARP pipeline once, then .spz."
+        )
+        row3b.addWidget(self._spz_only_chk)
+        self._remove_ply_chk = QCheckBox("Remove PLY after successful SPZ")
+        self._remove_ply_chk.setToolTip(
+            "Deletes the .ply only after .spz is written successfully. "
+            "The web preview tool is unchanged; batch only. "
+            "Without a PLY, the next batch run will run SHARP again for that image."
+        )
+        row3b.addWidget(self._remove_ply_chk)
+        row3b.addStretch()
+        layout.addLayout(row3b)
         self._limit_chk.toggled.connect(self._sync_limit_widgets)
+        self._spz_chk.toggled.connect(self._sync_remove_ply_widgets)
+        self._spz_only_chk.toggled.connect(self._on_spz_only_toggled)
         self._sync_limit_widgets()
         self._sync_force_skip_widgets(False)
+        self._on_spz_only_toggled(self._spz_only_chk.isChecked())
+        self._sync_remove_ply_widgets()
 
         row4 = QHBoxLayout()
         scan_btn = QPushButton("Scan & queue jobs")
@@ -191,6 +216,24 @@ class SharpBatchQtWindow(QMainWindow):
 
     def _sync_limit_widgets(self) -> None:
         self._max_edit.setEnabled(self._limit_chk.isChecked())
+
+    @Slot(bool)
+    def _on_spz_only_toggled(self, checked: bool) -> None:
+        if checked:
+            self._spz_chk.setChecked(True)
+            self._spz_chk.setEnabled(False)
+        else:
+            self._spz_chk.setEnabled(True)
+        self._sync_limit_widgets()
+        self._sync_remove_ply_widgets()
+
+    @Slot(bool)
+    def _sync_remove_ply_widgets(self, _checked: bool = False) -> None:
+        if self._spz_chk.isChecked():
+            self._remove_ply_chk.setEnabled(True)
+        else:
+            self._remove_ply_chk.setChecked(False)
+            self._remove_ply_chk.setEnabled(False)
 
     @Slot(bool)
     def _sync_force_skip_widgets(self, _checked: bool) -> None:
@@ -261,11 +304,15 @@ class SharpBatchQtWindow(QMainWindow):
                 if fr:
                     i_root = Path(fr).expanduser().resolve()
         spz = self._spz_chk.isChecked()
+        spz_only = self._spz_only_chk.isChecked()
+        rm_ply = self._remove_ply_chk.isChecked()
         with self._opts_lock:
             self._snap_lim = bool(lim)
             self._snap_max = mx if lim else None
             self._snap_skip = skip
             self._snap_spz = spz
+            self._snap_spz_only = spz_only
+            self._snap_remove_ply_after_spz = rm_ply
             self._snap_mirror_output = m_out
             self._snap_input_root = i_root
 
@@ -347,6 +394,7 @@ class SharpBatchQtWindow(QMainWindow):
             force_all=self._force_all_chk.isChecked(),
             mirror_output_root=mirror_out,
             export_spz=self._spz_chk.isChecked(),
+            spz_only=self._spz_only_chk.isChecked(),
         )
         if not jobs:
             if total_found == 0:
@@ -359,11 +407,20 @@ class SharpBatchQtWindow(QMainWindow):
                     "Photos → Settings → iCloud → Download Originals to this Mac.",
                 )
             else:
-                QMessageBox.information(
-                    self,
-                    "Scan",
-                    "No images need processing (PLY already up to date).",
-                )
+                if self._spz_only_chk.isChecked() and self._spz_chk.isChecked():
+                    QMessageBox.information(
+                        self,
+                        "Scan",
+                        "No work found: every image already has an .spz that is up "
+                        "to date with its PLY. Turn on Reprocess all to refresh .spz "
+                        "files anyway.",
+                    )
+                else:
+                    QMessageBox.information(
+                        self,
+                        "Scan",
+                        "No images need processing (PLY already up to date).",
+                    )
             return
 
         self._snapshot_opts()
@@ -506,6 +563,8 @@ class SharpBatchQtWindow(QMainWindow):
                 max_s = self._snap_max
                 skip = self._snap_skip
                 spz = self._snap_spz
+                spz_only = self._snap_spz_only
+                rm_ply = self._snap_remove_ply_after_spz
                 m_out = self._snap_mirror_output
                 i_root = self._snap_input_root
             try:
@@ -532,6 +591,8 @@ class SharpBatchQtWindow(QMainWindow):
                 max_splats=max_s if lim else None,
                 ply_output_path=ply_target,
                 export_spz=spz,
+                spz_only=spz_only,
+                remove_ply_after_spz=rm_ply,
             )
             if self._quit_app.is_set():
                 break

--- a/sharp_local_batch/gui_qt.py
+++ b/sharp_local_batch/gui_qt.py
@@ -32,10 +32,9 @@ from sharp_local_batch.core import (
     PlySidecarResult,
     default_macos_photos_library_path,
     is_photos_library_bundle,
-    needs_ply_refresh,
     output_ply_path_for_job,
-    process_image_to_sidecar_ply,
     sidecar_ply_path,
+    update_ply_sidecar,
 )
 
 
@@ -58,6 +57,7 @@ class SharpBatchQtWindow(QMainWindow):
         self._snap_lim = False
         self._snap_max: int | None = None
         self._snap_skip = True
+        self._snap_spz = True
         self._batch_total = 0
         self._batch_done = 0
         self._watch: WatchController | None = None
@@ -141,6 +141,9 @@ class SharpBatchQtWindow(QMainWindow):
         self._skip_chk = QCheckBox("Skip up-to-date PLY")
         self._skip_chk.setChecked(True)
         row3.addWidget(self._skip_chk)
+        self._spz_chk = QCheckBox("Export SPZ")
+        self._spz_chk.setChecked(True)
+        row3.addWidget(self._spz_chk)
         row3.addStretch()
         layout.addLayout(row3)
         self._limit_chk.toggled.connect(self._sync_limit_widgets)
@@ -257,10 +260,12 @@ class SharpBatchQtWindow(QMainWindow):
                 fr = self._folder_edit.text().strip()
                 if fr:
                     i_root = Path(fr).expanduser().resolve()
+        spz = self._spz_chk.isChecked()
         with self._opts_lock:
             self._snap_lim = bool(lim)
             self._snap_max = mx if lim else None
             self._snap_skip = skip
+            self._snap_spz = spz
             self._snap_mirror_output = m_out
             self._snap_input_root = i_root
 
@@ -341,6 +346,7 @@ class SharpBatchQtWindow(QMainWindow):
             self._recursive_chk.isChecked(),
             force_all=self._force_all_chk.isChecked(),
             mirror_output_root=mirror_out,
+            export_spz=self._spz_chk.isChecked(),
         )
         if not jobs:
             if total_found == 0:
@@ -499,6 +505,7 @@ class SharpBatchQtWindow(QMainWindow):
                 lim = self._snap_lim
                 max_s = self._snap_max
                 skip = self._snap_skip
+                spz = self._snap_spz
                 m_out = self._snap_mirror_output
                 i_root = self._snap_input_root
             try:
@@ -518,21 +525,14 @@ class SharpBatchQtWindow(QMainWindow):
                     break
                 self._bridge.job_finished.emit(r)
                 continue
-            if skip and not needs_ply_refresh(item, ply_target):
-                r = PlySidecarResult(
-                    ok=True,
-                    image_path=item,
-                    ply_path=ply_target,
-                    message="Skipped (PLY up to date)",
-                    skipped=True,
-                )
-            else:
-                r = process_image_to_sidecar_ply(
-                    item,
-                    limit_splats=lim,
-                    max_splats=max_s if lim else None,
-                    ply_output_path=ply_target,
-                )
+            r = update_ply_sidecar(
+                item,
+                skip_up_to_date=skip,
+                limit_splats=lim,
+                max_splats=max_s if lim else None,
+                ply_output_path=ply_target,
+                export_spz=spz,
+            )
             if self._quit_app.is_set():
                 break
             self._bridge.job_finished.emit(r)

--- a/static/index.html
+++ b/static/index.html
@@ -51,6 +51,10 @@
             disabled
             aria-label="Maximum splats when limiting"
           />
+          <label class="splat-limit-check">
+            <input type="checkbox" id="exportSpzCheck" checked />
+            <span>Export SPZ</span>
+          </label>
         </div>
         <p class="hint splat-limit-hint">
           Full-quality PLY is written first, then

--- a/static/main.js
+++ b/static/main.js
@@ -13,6 +13,7 @@ const btnFullscreen = document.getElementById("btnFullscreen");
 const splatScale = document.getElementById("splatScale");
 const limitSplatsCheck = document.getElementById("limitSplatsCheck");
 const maxSplatsInput = document.getElementById("maxSplatsInput");
+const exportSpzCheck = document.getElementById("exportSpzCheck");
 const splatInfo = document.getElementById("splatInfo");
 
 /** World-units per key press (fly mode); orbit mode scales slightly with distance. */
@@ -49,7 +50,16 @@ function setSplatInfoFromApi(data) {
   if (data.decimate_error) {
     text += ` — ${data.decimate_error}`;
   }
-  splatInfo.textContent = text;
+  splatInfo.innerHTML = "";
+  splatInfo.appendChild(document.createTextNode(text));
+  if (data.spz_url) {
+    const dl = document.createElement("a");
+    dl.href = data.spz_url;
+    dl.download = "";
+    dl.textContent = " (download .spz)";
+    dl.className = "spz-link";
+    splatInfo.appendChild(dl);
+  }
 }
 
 function setSplatInfoFromSelect() {
@@ -72,7 +82,16 @@ function setSplatInfoFromSelect() {
   if (opt.dataset.decimateError) {
     text += ` — ${opt.dataset.decimateError}`;
   }
-  splatInfo.textContent = text;
+  splatInfo.innerHTML = "";
+  splatInfo.appendChild(document.createTextNode(text));
+  if (opt.dataset.spzUrl) {
+    const dl = document.createElement("a");
+    dl.href = opt.dataset.spzUrl;
+    dl.download = "";
+    dl.textContent = " (download .spz)";
+    dl.className = "spz-link";
+    splatInfo.appendChild(dl);
+  }
 }
 
 async function disposeViewer() {
@@ -269,6 +288,7 @@ btnGenerate.addEventListener("click", async () => {
     const n = Number.isFinite(raw) && raw >= 1 ? Math.min(raw, 10_000_000) : 500_000;
     fd.append("max_splats", String(n));
   }
+  fd.append("export_spz", exportSpzCheck.checked ? "1" : "0");
   setStatus("Generating…", "working");
   btnGenerate.disabled = true;
   try {
@@ -334,6 +354,7 @@ async function refreshScenes(selectId = null) {
         if (s.splat_limit_applied) opt.dataset.splatLimited = "1";
         if (s.decimate_error) opt.dataset.decimateError = s.decimate_error;
       }
+      if (s.spz_url) opt.dataset.spzUrl = s.spz_url;
       sceneSelect.appendChild(opt);
     }
     if (selectId) {

--- a/static/style.css
+++ b/static/style.css
@@ -184,6 +184,15 @@ body {
   color: var(--muted);
 }
 
+.spz-link {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.spz-link:hover {
+  text-decoration: underline;
+}
+
 .btn {
   border: none;
   border-radius: var(--radius-sm);


### PR DESCRIPTION
## Description

This pull request introduces significant enhancements to the SHARP batch processing pipeline, focusing on improved support for exporting Niantic `.spz` files alongside or instead of `.ply` files. It adds new command-line options for batch workflows, refactors the SPZ export logic for reuse, and improves job scanning and status reporting to support these new workflows.
