### PR TITLE
GH-12: Create binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ python -m sharp_local_batch --cli --folder ~/Pictures/Photos\ Library.photoslibr
   --recursive --output-root /path/to/splat_mirror
 ```
 
+### Optional splat count reduction dependency (`splat-transform`)
+
+Optional splat count reduction (`--limit-splats`) uses the external PlayCanvas CLI `splat-transform`, which is not bundled. Install Node.js/npm from <https://nodejs.org/>, then:
+
+```bash
+npm install -g @playcanvas/splat-transform
+splat-transform --help
+```
+
 On **macOS**, the GUI can enable **Use system Photos library as source folder** — that **replaces** the main folder path (one source per run, not an extra directory); scan/watch use **`~/Pictures/Photos Library.photoslibrary`** while it is on, with mirrored PLY output; pick a **target folder for mirror** outside that bundle. Uncheck it to browse any other folder. Images are collected from **`originals/`** (or older libraries **`Masters/`**) inside the package, same as **`backend/api.py`** iCloud discovery — not only the bundle root. For the CLI, any **`.photoslibrary`** path passed to **`--folder`** requires **`--output-root`** and uses the same rules.
 
 In the GUI, enable **Mirror PLY output** and pick a **target folder for mirror** (must differ from the source folder). Default remains **next to each image**. For images under your home folder, mirrored PLY paths repeat from home (e.g. **`Pictures/Photos Library.photoslibrary/originals/…`**) instead of only **`originals/…`**; sources outside home still mirror relative to the chosen source root.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ In the GUI, enable **Mirror PLY output** and pick a **target folder for mirror**
 - **Batch tool:** `pyinstaller packaging/sharp_batch.spec` → **`dist/SharpBatch/`** (large: PyTorch + Qt). Run `./dist/SharpBatch/SharpBatch` (add `--cli …` for headless).
 - **Web UI (Flask):** `pyinstaller packaging/sharp_web.spec` → **`dist/SharpWeb/`**. Run `./dist/SharpWeb/SharpWeb`, then open **http://127.0.0.1:8765**. When frozen, scenes are written under the user data directory (on Windows: `%LOCALAPPDATA%\SharpLocal\outputs\`), not next to the executable.
 
-First inference still downloads the SHARP weights into the user cache unless you ship them separately. Distribute either bundle by zipping the whole output folder, including `_internal/`. On Windows you can also run **`compile-binaries-win.bat`** from the repo root after the venv is set up (see `docs/windows-setup.md`).
+First inference still downloads the SHARP weights into the user cache unless you ship them separately. Distribute either bundle by zipping the whole output folder, including `_internal/`. On macOS you can also run **`./compile-binaries-mac.sh`** from the repo root after the venv is set up (see `docs/mac-setup.md`). On Windows run **`compile-binaries-win.bat`** (see `docs/windows-setup.md`).
 
 ## Using the UI
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,12 @@ In the GUI, enable **Mirror PLY output** and pick a **target folder for mirror**
 
 **Homebrew Python without `_tkinter`:** use **PySide6-Essentials** from requirements; or `brew install python-tk@3.14` (match your Python minor) and recreate `.venv`; or use `--cli`.
 
-**Standalone build (PyInstaller):** with the repo venv active and `ml-sharp` present, run `pip install pyinstaller` then `pyinstaller packaging/sharp_batch.spec` from the repo root. The bundle is **`dist/SharpBatch/`** (large: PyTorch + Qt). Run `./dist/SharpBatch/SharpBatch` (add `--cli …` for headless). First inference still downloads the SHARP weights into the user cache unless you ship them separately.
+**Standalone builds (PyInstaller):** with the repo venv active and `ml-sharp` present, install PyInstaller (`pip install pyinstaller`), then from the repo root:
+
+- **Batch tool:** `pyinstaller packaging/sharp_batch.spec` → **`dist/SharpBatch/`** (large: PyTorch + Qt). Run `./dist/SharpBatch/SharpBatch` (add `--cli …` for headless).
+- **Web UI (Flask):** `pyinstaller packaging/sharp_web.spec` → **`dist/SharpWeb/`**. Run `./dist/SharpWeb/SharpWeb`, then open **http://127.0.0.1:8765**. When frozen, scenes are written under the user data directory (on Windows: `%LOCALAPPDATA%\SharpLocal\outputs\`), not next to the executable.
+
+First inference still downloads the SHARP weights into the user cache unless you ship them separately. Distribute either bundle by zipping the whole output folder, including `_internal/`. On Windows you can also run **`compile-binaries-win.bat`** from the repo root after the venv is set up (see `docs/windows-setup.md`).
 
 ## Using the UI
 

--- a/app.py
+++ b/app.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shutil
+import sys
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -45,9 +47,42 @@ from sharp_local_batch.core import (
     predictor_loaded,
 )
 
-EXPERIMENT_ROOT = Path(__file__).resolve().parent
-OUTPUTS_DIR = EXPERIMENT_ROOT / "outputs"
-STATIC_DIR = EXPERIMENT_ROOT / "static"
+def _dev_root() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def _bundle_root() -> Path:
+    """PyInstaller extract dir when frozen; repo root in development."""
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+        return Path(sys._MEIPASS)
+    return _dev_root()
+
+
+def _outputs_dir() -> Path:
+    """Scene PLY/SPZ under repo ``outputs/`` in dev; user-writable dir when frozen."""
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+        if sys.platform == "win32":
+            local = os.environ.get("LOCALAPPDATA")
+            if local:
+                return Path(local) / "SharpLocal" / "outputs"
+            return Path.home() / "AppData" / "Local" / "SharpLocal" / "outputs"
+        if sys.platform == "darwin":
+            return (
+                Path.home()
+                / "Library"
+                / "Application Support"
+                / "SharpLocal"
+                / "outputs"
+            )
+        xdg = os.environ.get("XDG_DATA_HOME")
+        if xdg:
+            return Path(xdg) / "sharp-local" / "outputs"
+        return Path.home() / ".local" / "share" / "sharp-local" / "outputs"
+    return _dev_root() / "outputs"
+
+
+STATIC_DIR = _bundle_root() / "static"
+OUTPUTS_DIR = _outputs_dir()
 
 
 def _configure_logger(name: str) -> logging.Logger:

--- a/app.py
+++ b/app.py
@@ -29,12 +29,13 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
-from flask import Flask, jsonify, request, send_file, send_from_directory
+from flask import Flask, Response, jsonify, request, send_file, send_from_directory
 
 from sharp_local_batch.logging_config import ensure_stderr_info_logging
 
 ensure_stderr_info_logging()
 
+from sharp_local_batch._version import __version__ as SHARP_LOCAL_VERSION
 from sharp_local_batch.core import (
     ML_SHARP_SRC,
     PREDICT_LOCK,
@@ -151,7 +152,11 @@ def favicon() -> Any:
 
 @app.route("/")
 def index() -> Any:
-    return send_from_directory(STATIC_DIR, "index.html")
+    """Serve ``index.html`` with title and heading tied to ``SHARP_LOCAL_VERSION``."""
+    path = STATIC_DIR / "index.html"
+    branding = f"Sharp Local web {SHARP_LOCAL_VERSION}"
+    body = path.read_text(encoding="utf-8").replace("__SHARP_LOCAL_WEB_TITLE__", branding)
+    return Response(body, mimetype="text/html; charset=utf-8")
 
 
 @app.route("/api/health")
@@ -160,6 +165,8 @@ def health() -> Any:
     return jsonify(
         {
             "ok": True,
+            "app": "sharp-local-web",
+            "version": SHARP_LOCAL_VERSION,
             "ml_sharp_path": str(ML_SHARP_SRC),
             "ml_sharp_present": ok,
             "model_loaded": predictor_loaded(),

--- a/compile-binaries-mac.sh
+++ b/compile-binaries-mac.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Build both standalone bundles on macOS:
+#   dist/SharpBatch/SharpBatch   — Qt GUI + CLI batch tool
+#   dist/SharpWeb/SharpWeb       — Flask web UI (open http://127.0.0.1:8765)
+#
+# Prerequisites: .venv already created and deps installed.
+#   Run ./bootstrap.sh first if you haven't yet.
+#   See docs/mac-setup.md for full developer setup instructions.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+cd "$ROOT"
+
+PYTHON=".venv/bin/python3"
+
+if [[ ! -x "$ROOT/$PYTHON" ]]; then
+  echo "ERROR: .venv not found at $ROOT/.venv" >&2
+  echo "Create the venv and install dependencies first — see docs/mac-setup.md" >&2
+  exit 1
+fi
+
+echo "Installing PyInstaller into .venv (if needed)..."
+"$ROOT/$PYTHON" -m pip install -q -U pyinstaller
+
+echo "Building SharpBatch..."
+"$ROOT/$PYTHON" -m PyInstaller packaging/sharp_batch.spec
+
+echo "Building SharpWeb..."
+"$ROOT/$PYTHON" -m PyInstaller packaging/sharp_web.spec
+
+echo ""
+echo "========================================================================"
+echo "Build finished OK."
+echo ""
+echo "Batch tool (GUI/CLI):"
+echo "  $ROOT/dist/SharpBatch/SharpBatch"
+echo "  Folder: $ROOT/dist/SharpBatch/"
+echo ""
+echo "Web UI (Flask server — open http://127.0.0.1:8765 after starting):"
+echo "  $ROOT/dist/SharpWeb/SharpWeb"
+echo "  Folder: $ROOT/dist/SharpWeb/"
+echo ""
+echo "Ship each app by zipping the whole folder above (include _internal/)."
+echo ""
+echo "NOTE: bundles built locally are not notarised. To open them the first"
+echo "  time: right-click → Open → Open, or run:"
+echo "  xattr -dr com.apple.quarantine dist/SharpBatch/"
+echo "========================================================================"

--- a/compile-binaries-win.bat
+++ b/compile-binaries-win.bat
@@ -1,0 +1,44 @@
+@echo off
+setlocal EnableExtensions
+cd /d "%~dp0"
+
+if not exist ".venv\Scripts\python.exe" (
+  echo ERROR: .venv not found at "%cd%\.venv"
+  echo Create the venv and install dependencies first — see docs\windows-setup.md
+  exit /b 1
+)
+
+echo Installing PyInstaller into .venv (if needed^)...
+".venv\Scripts\python.exe" -m pip install -q -U pyinstaller
+if errorlevel 1 exit /b 1
+
+echo Building SharpBatch...
+".venv\Scripts\python.exe" -m PyInstaller packaging\sharp_batch.spec
+if errorlevel 1 exit /b 1
+
+echo Building SharpWeb...
+".venv\Scripts\python.exe" -m PyInstaller packaging\sharp_web.spec
+if errorlevel 1 exit /b 1
+
+echo.
+echo ========================================================================
+echo Build finished OK.
+echo.
+echo Batch tool (GUI/CLI^):
+echo   %cd%\dist\SharpBatch\SharpBatch.exe
+echo   Folder: %cd%\dist\SharpBatch\
+echo.
+echo Web UI (Flask server — open http://127.0.0.1:8765 after starting^):
+echo   %cd%\dist\SharpWeb\SharpWeb.exe
+echo   Folder: %cd%\dist\SharpWeb\
+echo.
+echo Ship each app by zipping the whole folder above (include _internal^).
+echo ========================================================================
+if /i "%~1"=="nopause" (
+  endlocal
+  exit /b 0
+)
+echo.
+pause
+endlocal
+exit /b 0

--- a/docs/mac-setup.md
+++ b/docs/mac-setup.md
@@ -1,0 +1,108 @@
+# macOS development setup
+
+Developer instructions for building Sharp Local standalone bundles on macOS (batch tool and optional web UI). To run from source without PyInstaller, see the main [README](../README.md).
+
+## Prerequisites
+
+### Git
+
+Git ships with Xcode Command Line Tools. If it is not already installed:
+
+```bash
+xcode-select --install
+```
+
+Alternatively install via Homebrew: `brew install git`.
+
+### Python 3.13 (recommended) or 3.11 (fallback)
+
+**Option A – python.org installer (recommended for PyInstaller builds)**
+
+Download the universal2 macOS installer from <https://www.python.org/downloads/> and run it. This avoids Homebrew's PEP 668 `externally-managed-environment` restriction and produces cleaner standalone bundles.
+
+**Option B – Homebrew**
+
+```bash
+brew install python@3.13
+```
+
+Homebrew Python works fine for running from source. For PyInstaller builds it also works, but use the venv exclusively (never install packages globally).
+
+> After installing Python, close and reopen your terminal so the new `PATH` entries take effect.
+
+### Homebrew (optional but recommended)
+
+If you don't have Homebrew yet and want it for other tools:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+## Clone and install
+
+```bash
+git clone --recurse-submodules https://github.com/hkirsman/sharp-local.git
+cd sharp-local
+./bootstrap.sh
+```
+
+`bootstrap.sh` creates `.venv`, syncs the `ml-sharp` submodule to the pinned commit, and installs all Python dependencies. Manual equivalent if you need it:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install -U pip
+python3 -m pip install -e ./ml-sharp -r requirements.txt
+```
+
+## Build both bundles (shortcut)
+
+From the repo root with the venv **activated**:
+
+```bash
+./compile-binaries-mac.sh
+```
+
+This installs PyInstaller into `.venv` if needed, then builds both specs. For use in CI (no interactive pause), the script exits cleanly on its own.
+
+## Build standalone batch bundle
+
+```bash
+source .venv/bin/activate
+python -m pip install pyinstaller
+pyinstaller packaging/sharp_batch.spec
+```
+
+Output: `dist/SharpBatch/SharpBatch` (with `_internal/` beside it).
+
+Run it directly or pass CLI flags:
+
+```bash
+./dist/SharpBatch/SharpBatch
+./dist/SharpBatch/SharpBatch --cli --folder ~/Photos --recursive
+```
+
+To distribute, zip the entire `dist/SharpBatch/` folder (including `_internal/`) — recipients unzip the whole folder and run `SharpBatch` (no Python or Git required).
+
+## Build standalone web UI bundle
+
+Same venv and dependencies as above, then:
+
+```bash
+pyinstaller packaging/sharp_web.spec
+```
+
+Output: `dist/SharpWeb/SharpWeb`. Run it, then open **http://127.0.0.1:8765** in a browser.
+
+When frozen, generated scenes are stored under `~/Library/Application Support/SharpLocal/outputs/` (not next to the binary). Zip `dist/SharpWeb/` the same way as the batch bundle.
+
+## Notes
+
+- **First inference** downloads the SHARP model checkpoint (~2.6 GB) into `~/.cache/torch/hub/checkpoints/`. Make sure you have internet access and enough disk space before the first run.
+- **Apple Silicon (MPS acceleration):** PyTorch uses the Metal Performance Shaders (MPS) backend automatically on Apple Silicon Macs. No extra setup is needed. Inference is substantially faster than CPU.
+- **Intel Mac:** inference runs on CPU. GPU acceleration via CUDA is not available on macOS.
+- **Gatekeeper / "can't be opened" warning:** bundles built locally are not notarised. To open them the first time, right-click → **Open** → **Open** in the dialog, or run `xattr -dr com.apple.quarantine dist/SharpBatch/` after building.
+- **Bundle size:** standalone bundles are large (PyTorch; the batch build also includes Qt). This is expected.
+- **Python version mismatch:** if you switch Python versions, delete `.venv` and rerun `bootstrap.sh` before rebuilding.
+- **_tkinter missing:** Homebrew Pythons may lack Tcl/Tk. Install `brew install python-tk@3.13` (match your Python minor) and recreate `.venv`, or use `--cli`, or rely on the PySide6 GUI (already in `requirements.txt`).
+- **macOS Photos Library:** the GUI can enable **Use system Photos library as source folder** (`~/Pictures/Photos Library.photoslibrary`). PLY output must be mirrored outside the bundle — enable **Mirror PLY output** and pick a target folder. For the CLI pass `--output-root /path/to/mirror`.

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -8,9 +8,13 @@ Developer instructions for building and running Sharp Local from source on Windo
 
 Download from <https://git-scm.com/download/win> and run the installer (defaults are fine).
 
-### Python 3.11 or 3.12
+### Python 3.13 (recommended) or 3.11 (fallback)
 
 Download from <https://www.python.org/downloads/>.
+
+Use the latest Python 3.13 installer on Windows.
+
+If package install issues occur in your environment, use Python 3.11 instead.
 
 **Important:** on the first installer screen, check **"Add python.exe to PATH"** before clicking Install.
 
@@ -66,9 +70,8 @@ Then open **http://127.0.0.1:8765** in a browser.
 ## Build a standalone `.exe`
 
 ```powershell
-.venv\Scripts\activate
-pip install pyinstaller
-pyinstaller packaging/sharp_batch.spec
+.\.venv\Scripts\python -m pip install pyinstaller
+.\.venv\Scripts\pyinstaller packaging/sharp_batch.spec
 ```
 
 Output: `dist\SharpBatch\SharpBatch.exe`
@@ -87,4 +90,5 @@ To distribute to end users, zip the entire `dist\SharpBatch\` folder — recipie
 - The **first inference** downloads the SHARP model checkpoint (~2.6 GB) into the user cache (`%LOCALAPPDATA%\torch\hub\checkpoints\`). Make sure you have internet access and enough disk space.
 - Default PyTorch includes CPU support, which works fine. For GPU acceleration with an NVIDIA card, see <https://pytorch.org/get-started/locally/> to install the CUDA-enabled version instead.
 - The standalone bundle is large (PyTorch + Qt). This is expected.
+- If command discovery differs between terminals (for example Cursor terminal vs external PowerShell), run tools with explicit paths like `.\.venv\Scripts\python ...` and `.\.venv\Scripts\pyinstaller ...`.
 - For automated CI builds, see the GitHub Actions example in the main [README](../README.md).

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -1,6 +1,6 @@
 # Windows development setup
 
-Developer instructions for building and running Sharp Local from source on Windows.
+Developer instructions for building Sharp Local standalone `.exe` bundles on Windows (batch tool and optional web UI). To run from source without PyInstaller, see the main [README](../README.md).
 
 ## Prerequisites
 
@@ -35,46 +35,22 @@ python -m pip install -U pip
 python -m pip install -e ./ml-sharp -r requirements.txt
 ```
 
-## Run from source
+## Build both `.exe` bundles (shortcut)
 
-### Batch tool — GUI
+From the repo root in **Command Prompt**, or by double‑clicking in Explorer:
 
-```powershell
-.venv\Scripts\activate
-python -m sharp_local_batch
-```
+`compile-binaries-win.bat`
 
-### Batch tool — CLI (no GUI needed)
+This installs PyInstaller into `.venv` if needed, then runs `packaging\sharp_batch.spec` and `packaging\sharp_web.spec`. For unattended use (no `pause` at the end), run `compile-binaries-win.bat nopause`.
 
-```powershell
-.venv\Scripts\activate
-python -m sharp_local_batch --cli --folder C:\path\to\photos --recursive
-```
-
-With mirrored output:
-
-```powershell
-python -m sharp_local_batch --cli --folder C:\path\to\photos --recursive ^
-  --output-root C:\path\to\splat_mirror
-```
-
-### Web UI
-
-```powershell
-.venv\Scripts\activate
-python app.py
-```
-
-Then open **http://127.0.0.1:8765** in a browser.
-
-## Build a standalone `.exe`
+## Build standalone batch `.exe`
 
 ```powershell
 .\.venv\Scripts\python -m pip install pyinstaller
 .\.venv\Scripts\pyinstaller packaging/sharp_batch.spec
 ```
 
-Output: `dist\SharpBatch\SharpBatch.exe`
+Output: `dist\SharpBatch\SharpBatch.exe` (with `_internal\` beside it).
 
 Run it directly or pass CLI flags:
 
@@ -83,12 +59,24 @@ dist\SharpBatch\SharpBatch.exe
 dist\SharpBatch\SharpBatch.exe --cli --folder C:\photos --recursive
 ```
 
-To distribute to end users, zip the entire `dist\SharpBatch\` folder — recipients just unzip and run `SharpBatch.exe` (no Python or Git needed on their machine).
+To distribute, zip the entire `dist\SharpBatch\` folder (including `_internal`) — recipients unzip the whole folder and run `SharpBatch.exe` (no Python or Git needed on their machine).
+
+## Build standalone web UI `.exe`
+
+Same venv and dependencies as above, then:
+
+```powershell
+.\.venv\Scripts\pyinstaller packaging/sharp_web.spec
+```
+
+Output: `dist\SharpWeb\SharpWeb.exe`. Run it, then open **http://127.0.0.1:8765** in a browser.
+
+When frozen, generated scenes are stored under `%LOCALAPPDATA%\SharpLocal\outputs\` (not next to the `.exe`). Zip `dist\SharpWeb\` the same way as the batch bundle (include `_internal`).
 
 ## Notes
 
 - The **first inference** downloads the SHARP model checkpoint (~2.6 GB) into the user cache (`%LOCALAPPDATA%\torch\hub\checkpoints\`). Make sure you have internet access and enough disk space.
 - Default PyTorch includes CPU support, which works fine. For GPU acceleration with an NVIDIA card, see <https://pytorch.org/get-started/locally/> to install the CUDA-enabled version instead.
-- The standalone bundle is large (PyTorch + Qt). This is expected.
+- The standalone bundles are large (PyTorch; the batch build also includes Qt). This is expected.
 - If command discovery differs between terminals (for example Cursor terminal vs external PowerShell), run tools with explicit paths like `.\.venv\Scripts\python ...` and `.\.venv\Scripts\pyinstaller ...`.
 - For automated CI builds, see the GitHub Actions example in the main [README](../README.md).

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -1,0 +1,90 @@
+# Windows development setup
+
+Developer instructions for building and running Sharp Local from source on Windows.
+
+## Prerequisites
+
+### Git
+
+Download from <https://git-scm.com/download/win> and run the installer (defaults are fine).
+
+### Python 3.11 or 3.12
+
+Download from <https://www.python.org/downloads/>.
+
+**Important:** on the first installer screen, check **"Add python.exe to PATH"** before clicking Install.
+
+> After installing both, close and reopen your terminal so the new `PATH` entries take effect.
+
+## Clone and install
+
+Open **PowerShell** (or Command Prompt) and run:
+
+```powershell
+git clone --recurse-submodules https://github.com/hkirsman/sharp-local.git
+cd sharp-local
+
+python -m venv .venv
+.venv\Scripts\activate
+
+python -m pip install -U pip
+python -m pip install -e ./ml-sharp -r requirements.txt
+```
+
+## Run from source
+
+### Batch tool — GUI
+
+```powershell
+.venv\Scripts\activate
+python -m sharp_local_batch
+```
+
+### Batch tool — CLI (no GUI needed)
+
+```powershell
+.venv\Scripts\activate
+python -m sharp_local_batch --cli --folder C:\path\to\photos --recursive
+```
+
+With mirrored output:
+
+```powershell
+python -m sharp_local_batch --cli --folder C:\path\to\photos --recursive ^
+  --output-root C:\path\to\splat_mirror
+```
+
+### Web UI
+
+```powershell
+.venv\Scripts\activate
+python app.py
+```
+
+Then open **http://127.0.0.1:8765** in a browser.
+
+## Build a standalone `.exe`
+
+```powershell
+.venv\Scripts\activate
+pip install pyinstaller
+pyinstaller packaging/sharp_batch.spec
+```
+
+Output: `dist\SharpBatch\SharpBatch.exe`
+
+Run it directly or pass CLI flags:
+
+```powershell
+dist\SharpBatch\SharpBatch.exe
+dist\SharpBatch\SharpBatch.exe --cli --folder C:\photos --recursive
+```
+
+To distribute to end users, zip the entire `dist\SharpBatch\` folder — recipients just unzip and run `SharpBatch.exe` (no Python or Git needed on their machine).
+
+## Notes
+
+- The **first inference** downloads the SHARP model checkpoint (~2.6 GB) into the user cache (`%LOCALAPPDATA%\torch\hub\checkpoints\`). Make sure you have internet access and enough disk space.
+- Default PyTorch includes CPU support, which works fine. For GPU acceleration with an NVIDIA card, see <https://pytorch.org/get-started/locally/> to install the CUDA-enabled version instead.
+- The standalone bundle is large (PyTorch + Qt). This is expected.
+- For automated CI builds, see the GitHub Actions example in the main [README](../README.md).

--- a/packaging/entry_batch.py
+++ b/packaging/entry_batch.py
@@ -6,8 +6,12 @@ import multiprocessing
 
 
 def main() -> None:
-    from sharp_local_batch.__main__ import main as batch_main
+    import logging
 
+    from sharp_local_batch.__main__ import main as batch_main
+    from sharp_local_batch._version import __version__
+
+    logging.getLogger("SharpBatch").info("Sharp Local batch %s", __version__)
     batch_main()
 
 

--- a/packaging/entry_web.py
+++ b/packaging/entry_web.py
@@ -8,8 +8,10 @@ import multiprocessing
 
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
-    from app import OUTPUTS_DIR, app
+    from sharp_local_batch._version import __version__
+    from app import LOGGER, OUTPUTS_DIR, app
 
+    LOGGER.info("Sharp Local web %s — http://127.0.0.1:8765", __version__)
     OUTPUTS_DIR.mkdir(parents=True, exist_ok=True)
     app.run(host="127.0.0.1", port=8765, debug=False, threaded=True)
 

--- a/packaging/entry_web.py
+++ b/packaging/entry_web.py
@@ -1,0 +1,19 @@
+"""PyInstaller entrypoint: run the Flask web UI (``app.py``)."""
+
+from __future__ import annotations
+
+import logging
+import multiprocessing
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    from app import OUTPUTS_DIR, app
+
+    OUTPUTS_DIR.mkdir(parents=True, exist_ok=True)
+    app.run(host="127.0.0.1", port=8765, debug=False, threaded=True)
+
+
+if __name__ == "__main__":
+    multiprocessing.freeze_support()
+    main()

--- a/packaging/sharp_batch.spec
+++ b/packaging/sharp_batch.spec
@@ -36,6 +36,7 @@ hiddenimports = (
     collect_submodules("sharp")
     + [
         "sharp_local_batch",
+        "sharp_local_batch._version",
         "sharp_local_batch.core",
         "sharp_local_batch.batch_runner",
         "sharp_local_batch.gui_qt",

--- a/packaging/sharp_web.spec
+++ b/packaging/sharp_web.spec
@@ -37,6 +37,7 @@ for pkg in ("flask", "werkzeug", "jinja2"):
 hiddenimports = collect_submodules("sharp") + [
     "app",
     "sharp_local_batch",
+    "sharp_local_batch._version",
     "sharp_local_batch.core",
     "sharp_local_batch.logging_config",
     "plyfile",

--- a/packaging/sharp_web.spec
+++ b/packaging/sharp_web.spec
@@ -1,0 +1,100 @@
+# -*- mode: python ; coding: utf-8 -*-
+#
+# Build a standalone Flask web UI (app.py → browser at http://127.0.0.1:8765).
+#
+# From the repository root (with .venv and deps installed):
+#   pip install pyinstaller
+#   pyinstaller packaging/sharp_web.spec
+#
+# Output: dist/SharpWeb/  (large: PyTorch; no Qt unless pulled transitively.)
+#
+import pathlib
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules, copy_metadata
+
+block_cipher = None
+
+REPO = pathlib.Path(SPECPATH).resolve().parent
+
+datas = []
+if (REPO / "ml-sharp" / "src").is_dir():
+    datas.append((str(REPO / "ml-sharp" / "src"), "ml-sharp/src"))
+if (REPO / "static").is_dir():
+    datas.append((str(REPO / "static"), "static"))
+
+datas += copy_metadata("imageio")
+try:
+    datas += copy_metadata("imageio-ffmpeg")
+except Exception:
+    pass
+
+for pkg in ("flask", "werkzeug", "jinja2"):
+    try:
+        datas += collect_data_files(pkg)
+    except Exception:
+        pass
+
+hiddenimports = collect_submodules("sharp") + [
+    "app",
+    "sharp_local_batch",
+    "sharp_local_batch.core",
+    "sharp_local_batch.logging_config",
+    "plyfile",
+    "PIL",
+    "PIL.Image",
+    "gaussforge",
+    "imageio",
+    "imageio.v2",
+    "imageio.core",
+    "imageio.plugins",
+    "flask",
+    "werkzeug",
+    "jinja2",
+]
+
+a = Analysis(
+    [str(REPO / "packaging" / "entry_web.py")],
+    pathex=[str(REPO)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="SharpWeb",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="SharpWeb",
+)

--- a/sharp_local_batch/__init__.py
+++ b/sharp_local_batch/__init__.py
@@ -1,3 +1,5 @@
 """Batch and filesystem-watch SHARP splat generation (PLY beside images or mirrored)."""
 
-__all__ = ["core"]
+from sharp_local_batch._version import __version__
+
+__all__ = ["core", "__version__"]

--- a/sharp_local_batch/__main__.py
+++ b/sharp_local_batch/__main__.py
@@ -20,8 +20,15 @@ from sharp_local_batch.core import (
 
 
 def _cli_main() -> int:
+    from sharp_local_batch._version import __version__
+
     p = argparse.ArgumentParser(
         description="SHARP batch: PLY beside each image, or under --output-root when mirroring.",
+    )
+    p.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
     )
     p.add_argument(
         "--folder",
@@ -208,6 +215,11 @@ def _is_expected_missing_qt(exc: ImportError) -> bool:
 
 
 def main() -> None:
+    if len(sys.argv) == 2 and sys.argv[1] in ("--version", "-V"):
+        from sharp_local_batch._version import __version__
+
+        print(f"sharp-local-batch {__version__}")
+        raise SystemExit(0)
     if len(sys.argv) >= 2 and sys.argv[1] == "--cli":
         sys.argv.pop(1)
         raise SystemExit(_cli_main())

--- a/sharp_local_batch/_version.py
+++ b/sharp_local_batch/_version.py
@@ -1,0 +1,3 @@
+"""Sharp Local (batch + web) application version. Bump on release (semantic versioning)."""
+
+__version__ = "0.1.0"

--- a/sharp_local_batch/gui.py
+++ b/sharp_local_batch/gui.py
@@ -25,7 +25,9 @@ from sharp_local_batch.core import (
 class SharpBatchGui:
     def __init__(self) -> None:
         self.root = tk.Tk()
-        self.root.title("sharp_local_batch")
+        from sharp_local_batch._version import __version__
+
+        self.root.title(f"Sharp Local batch {__version__}")
         self.root.minsize(640, 440)
 
         self._folder_var = tk.StringVar(value="")

--- a/sharp_local_batch/gui_qt.py
+++ b/sharp_local_batch/gui_qt.py
@@ -48,7 +48,9 @@ class _Bridge(QObject):
 class SharpBatchQtWindow(QMainWindow):
     def __init__(self) -> None:
         super().__init__()
-        self.setWindowTitle("sharp_local_batch")
+        from sharp_local_batch._version import __version__
+
+        self.setWindowTitle(f"Sharp Local batch {__version__}")
         self.resize(720, 540)
 
         self._job_q: queue.Queue[Path] = queue.Queue()

--- a/static/index.html
+++ b/static/index.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Title and main heading are filled by Flask from sharp_local_batch._version -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SHARP</title>
+    <title>__SHARP_LOCAL_WEB_TITLE__</title>
     <link rel="stylesheet" href="/style.css" />
     <script type="importmap">
       {
@@ -16,7 +17,7 @@
   </head>
   <body>
     <header class="page-header">
-      <h1 class="title">SHARP</h1>
+      <h1 class="title">__SHARP_LOCAL_WEB_TITLE__</h1>
       <p class="subtitle">Transform images into 3D Gaussian Splats.</p>
     </header>
 


### PR DESCRIPTION
This pull request adds robust support for building and distributing standalone binaries for both the batch tool and the web UI using PyInstaller, with full cross-platform support for macOS and Windows. It introduces new build scripts, detailed setup documentation, and makes several codebase improvements to ensure correct resource handling and version reporting in both development and frozen (bundled) environments.

**Standalone build and distribution improvements:**

- Added PyInstaller spec files for both the batch tool (`packaging/sharp_batch.spec`) and the web UI (`packaging/sharp_web.spec`), ensuring all necessary dependencies and resources are included for standalone distribution. [[1]](diffhunk://#diff-b59c834a053f52150508686f5347c3e3cd84eb3cf37f51ed77e9ae7e5b5974a9R39) [[2]](diffhunk://#diff-e7d5f9af33838cabc7ba9736195c1969f889200282352c1889e4008c6d30dd4aR1-R101)
- Introduced build scripts for macOS (`compile-binaries-mac.sh`) and Windows (`compile-binaries-win.bat`) to automate the process of building both bundles and provide clear output and instructions. [[1]](diffhunk://#diff-712a4e16196a25e956b06131dd10f7299058dc5d7671e0385ac3ac49123add87R1-R47) [[2]](diffhunk://#diff-8b0740d6bb73142955294a2d55ff0e27f4cced2deab803a07c321f2d3c67b968R1-R44)
- Added platform-specific documentation for setting up development and building binaries: `docs/mac-setup.md` for macOS and `docs/windows-setup.md` for Windows. [[1]](diffhunk://#diff-48648667f62a2a57a1ac87dc5ba5e4a482591d434abd094823eb77606360c292R1-R108) [[2]](diffhunk://#diff-3bbc02ed47a6a97c38b776b5a55feebc423dbe53a8c85be957d03925a38d0ddcR1-R82)

**Resource and path handling enhancements:**

- Refactored output and static file path resolution in `app.py` to ensure scenes and static assets are written to appropriate user-writable directories when running as a frozen binary, supporting both Windows and macOS conventions.
- Ensured the web UI and batch tool display and report their version using the new `sharp_local_batch._version` module, and improved branding in the web UI. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R24-R38) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L119-R159) [[3]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R168-R169) [[4]](diffhunk://#diff-30179e72d80acc77af62536b128dd4e9c0c91aa00f385f13dd825913335e431aR9-R14) [[5]](diffhunk://#diff-86e5f35950f4c9e58f5df6e1fe52bc0b2a9ed72ce346f09a11e068580a422dc3L3-R5) [[6]](diffhunk://#diff-a21c326bd5ef061a6d2f0ff14c07e9fc263a8a58190b6e6c6d3bf5d52af15477R23-R32) [[7]](diffhunk://#diff-a21c326bd5ef061a6d2f0ff14c07e9fc263a8a58190b6e6c6d3bf5d52af15477R218-R222)

**Entrypoint and CLI improvements:**

- Added PyInstaller-specific entrypoints for both the batch tool (`packaging/entry_batch.py`) and the web UI (`packaging/entry_web.py`) to ensure correct initialization, logging, and multiprocessing support. [[1]](diffhunk://#diff-30179e72d80acc77af62536b128dd4e9c0c91aa00f385f13dd825913335e431aR9-R14) [[2]](diffhunk://#diff-8c8396dc4ff16a54f6a36ae2fc8f4342477f87bb08b0eeb902fc7fd71a5c1bc3R1-R21)
- Improved CLI version reporting and added a `--version` flag for the batch tool. [[1]](diffhunk://#diff-a21c326bd5ef061a6d2f0ff14c07e9fc263a8a58190b6e6c6d3bf5d52af15477R23-R32) [[2]](diffhunk://#diff-a21c326bd5ef061a6d2f0ff14c07e9fc263a8a58190b6e6c6d3bf5d52af15477R218-R222)

**Documentation updates:**

- Updated the main `README.md` to document the new build process, clarify distribution instructions, and explain the optional dependency for splat count reduction.

**Summary of most important changes:**

**Standalone build system and cross-platform support:**
- Added PyInstaller spec files for both the batch tool and web UI, ensuring all dependencies and resources are bundled for standalone distribution. [[1]](diffhunk://#diff-b59c834a053f52150508686f5347c3e3cd84eb3cf37f51ed77e9ae7e5b5974a9R39) [[2]](diffhunk://#diff-e7d5f9af33838cabc7ba9736195c1969f889200282352c1889e4008c6d30dd4aR1-R101)
- Introduced platform-specific build scripts and setup documentation for macOS and Windows to streamline developer workflows and distribution. [[1]](diffhunk://#diff-712a4e16196a25e956b06131dd10f7299058dc5d7671e0385ac3ac49123add87R1-R47) [[2]](diffhunk://#diff-8b0740d6bb73142955294a2d55ff0e27f4cced2deab803a07c321f2d3c67b968R1-R44) [[3]](diffhunk://#diff-48648667f62a2a57a1ac87dc5ba5e4a482591d434abd094823eb77606360c292R1-R108) [[4]](diffhunk://#diff-3bbc02ed47a6a97c38b776b5a55feebc423dbe53a8c85be957d03925a38d0ddcR1-R82)

**Application resource handling and versioning:**
- Refactored path handling in `app.py` to write outputs and serve static assets correctly in both development and frozen (PyInstaller) environments, following OS conventions.
- Centralized application version reporting and branding for both CLI and web UI, improving user feedback and traceability. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R24-R38) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L119-R159) [[3]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R168-R169) [[4]](diffhunk://#diff-30179e72d80acc77af62536b128dd4e9c0c91aa00f385f13dd825913335e431aR9-R14) [[5]](diffhunk://#diff-86e5f35950f4c9e58f5df6e1fe52bc0b2a9ed72ce346f09a11e068580a422dc3L3-R5) [[6]](diffhunk://#diff-a21c326bd5ef061a6d2f0ff14c07e9fc263a8a58190b6e6c6d3bf5d52af15477R23-R32) [[7]](diffhunk://#diff-a21c326bd5ef061a6d2f0ff14c07e9fc263a8a58190b6e6c6d3bf5d52af15477R218-R222)

**Entrypoint and CLI improvements:**
- Added PyInstaller entrypoints for both batch and web UI, ensuring proper initialization, logging, and multiprocessing support in frozen mode. [[1]](diffhunk://#diff-30179e72d80acc77af62536b128dd4e9c0c91aa00f385f13dd825913335e431aR9-R14) [[2]](diffhunk://#diff-8c8396dc4ff16a54f6a36ae2fc8f4342477f87bb08b0eeb902fc7fd71a5c1bc3R1-R21)

**Documentation and user guidance:**
- Updated `README.md` and added platform-specific setup docs to guide users through installation, building, and distribution of standalone binaries. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R86-R106) [[2]](diffhunk://#diff-48648667f62a2a57a1ac87dc5ba5e4a482591d434abd094823eb77606360c292R1-R108) [[3]](diffhunk://#diff-3bbc02ed47a6a97c38b776b5a55feebc423dbe53a8c85be957d03925a38d0ddcR1-R82)