### PR TITLE
GH-14: Skip files with existing up-to-date SPZ

### DIFF
--- a/sharp_local_batch/batch_runner.py
+++ b/sharp_local_batch/batch_runner.py
@@ -13,6 +13,7 @@ from watchdog.observers import Observer
 from sharp_local_batch.core import (
     PlySidecarResult,
     effective_batch_scan_root,
+    is_spz_current_for_image,
     is_supported_image,
     list_image_paths,
     mirrored_ply_path,
@@ -22,17 +23,6 @@ from sharp_local_batch.core import (
     sidecar_ply_path,
     update_ply_sidecar,
 )
-
-
-def _spz_is_current(ply_path: Path, image_path: Path) -> bool:
-    """True when PLY is absent but its .spz sidecar exists and is current vs the image."""
-    spz = ply_path.with_suffix(".spz")
-    if not spz.is_file():
-        return False
-    try:
-        return spz.stat().st_mtime >= image_path.stat().st_mtime
-    except OSError:
-        return False
 
 
 def scan_jobs(
@@ -73,7 +63,7 @@ def scan_jobs(
                 if not ply.is_file():
                     if force_all:
                         return True
-                    return not _spz_is_current(ply, p)
+                    return not is_spz_current_for_image(ply, p)
                 if force_all:
                     return True
                 return needs_spz_refresh(ply)
@@ -90,7 +80,7 @@ def scan_jobs(
             if not target.is_file():
                 if force_all:
                     return True
-                return not _spz_is_current(target, p)
+                return not is_spz_current_for_image(target, p)
             if force_all:
                 return True
             return needs_spz_refresh(target)

--- a/sharp_local_batch/batch_runner.py
+++ b/sharp_local_batch/batch_runner.py
@@ -39,11 +39,12 @@ def scan_jobs(
     When ``export_spz`` is set, files whose PLY is current but ``.spz`` sidecar
     is missing are still queued so the worker can top up the SPZ.
 
-    When ``spz_only`` is set (requires ``export_spz``), images **without** a
-    target PLY are still queued so the worker can run the full SHARP pipeline
-    once.  Images that already have a PLY are queued when ``.spz`` is missing,
-    stale vs that PLY, or when ``force_all`` is set.  The worker then converts
-    PLY → SPZ without SHARP only when the PLY already exists.
+    When ``spz_only`` is set (requires ``export_spz``), images without a
+    target PLY are queued only when no current ``.spz`` sidecar exists (or
+    when ``force_all`` is set).  Images that already have a PLY are queued
+    when ``.spz`` is missing, stale vs that PLY, or when ``force_all`` is
+    set.  The worker converts PLY → SPZ without SHARP only when the PLY
+    already exists.
 
     Returns ``(jobs, total_supported_images)`` where *total_supported_images* is the
     count of supported files found before the PLY-freshness filter — useful to tell

--- a/sharp_local_batch/batch_runner.py
+++ b/sharp_local_batch/batch_runner.py
@@ -24,6 +24,17 @@ from sharp_local_batch.core import (
 )
 
 
+def _spz_is_current(ply_path: Path, image_path: Path) -> bool:
+    """True when PLY is absent but its .spz sidecar exists and is current vs the image."""
+    spz = ply_path.with_suffix(".spz")
+    if not spz.is_file():
+        return False
+    try:
+        return spz.stat().st_mtime >= image_path.stat().st_mtime
+    except OSError:
+        return False
+
+
 def scan_jobs(
     root: Path,
     recursive: bool,
@@ -60,16 +71,9 @@ def scan_jobs(
             def _spz_only_need(p: Path) -> bool:
                 ply = sidecar_ply_path(p)
                 if not ply.is_file():
-                    # PLY missing — check if SPZ already exists and is current
-                    # (PLY may have been removed after a previous SPZ export).
-                    spz = ply.with_suffix(".spz")
-                    if spz.is_file():
-                        try:
-                            if spz.stat().st_mtime >= p.stat().st_mtime:
-                                return False
-                        except OSError:
-                            pass
-                    return True
+                    if force_all:
+                        return True
+                    return not _spz_is_current(ply, p)
                 if force_all:
                     return True
                 return needs_spz_refresh(ply)
@@ -84,15 +88,9 @@ def scan_jobs(
             except ValueError:
                 return True
             if not target.is_file():
-                # PLY missing — check if SPZ already exists and is current.
-                spz = target.with_suffix(".spz")
-                if spz.is_file():
-                    try:
-                        if spz.stat().st_mtime >= p.stat().st_mtime:
-                            return False
-                    except OSError:
-                        pass
-                return True
+                if force_all:
+                    return True
+                return not _spz_is_current(target, p)
             if force_all:
                 return True
             return needs_spz_refresh(target)

--- a/sharp_local_batch/batch_runner.py
+++ b/sharp_local_batch/batch_runner.py
@@ -60,6 +60,15 @@ def scan_jobs(
             def _spz_only_need(p: Path) -> bool:
                 ply = sidecar_ply_path(p)
                 if not ply.is_file():
+                    # PLY missing — check if SPZ already exists and is current
+                    # (PLY may have been removed after a previous SPZ export).
+                    spz = ply.with_suffix(".spz")
+                    if spz.is_file():
+                        try:
+                            if spz.stat().st_mtime >= p.stat().st_mtime:
+                                return False
+                        except OSError:
+                            pass
                     return True
                 if force_all:
                     return True
@@ -75,6 +84,14 @@ def scan_jobs(
             except ValueError:
                 return True
             if not target.is_file():
+                # PLY missing — check if SPZ already exists and is current.
+                spz = target.with_suffix(".spz")
+                if spz.is_file():
+                    try:
+                        if spz.stat().st_mtime >= p.stat().st_mtime:
+                            return False
+                    except OSError:
+                        pass
                 return True
             if force_all:
                 return True

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -580,16 +580,17 @@ def update_ply_sidecar(
     When ``skip_up_to_date`` is set and the PLY is already current, this
     avoids re-running inference: if ``export_spz`` is on but the ``.spz``
     sidecar is missing, only the SPZ conversion runs against the existing
-    PLY; otherwise the file is reported as skipped.  In all other cases the
-    full :func:`process_image_to_sidecar_ply` pipeline runs.
+    PLY; otherwise the file is reported as skipped.  When the PLY is missing
+    but a current ``.spz`` sidecar exists (e.g. PLY was removed after a
+    previous export), the file is also skipped — in both normal and
+    ``spz_only`` modes.  In all other cases the full
+    :func:`process_image_to_sidecar_ply` pipeline runs.
 
     When ``spz_only`` is set (with ``export_spz``) and a PLY already exists at
     the target path, SHARP is not run: optional ``limit_splats`` /
     ``max_splats`` runs ``decimate_ply_splat_transform`` on that file, then
-    ``export_ply_to_spz``.  If there is **no** PLY yet but a current ``.spz``
-    sidecar exists (e.g. PLY was removed after a previous export), the file is
-    skipped when ``skip_up_to_date`` is set.  Otherwise this falls back to the
-    full :func:`process_image_to_sidecar_ply` pipeline.
+    ``export_ply_to_spz``.  If there is **no** PLY and no current ``.spz``,
+    this falls back to the full pipeline.
 
     When ``remove_ply_after_spz`` is set, the target ``.ply`` is deleted after a
     successful ``.spz`` write (batch use; keeps disk usage down).

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -586,9 +586,10 @@ def update_ply_sidecar(
     When ``spz_only`` is set (with ``export_spz``) and a PLY already exists at
     the target path, SHARP is not run: optional ``limit_splats`` /
     ``max_splats`` runs ``decimate_ply_splat_transform`` on that file, then
-    ``export_ply_to_spz``.  If there is **no** PLY yet, this falls back to the
-    full :func:`process_image_to_sidecar_ply` pipeline (inference, optional
-    decimate, SPZ) so a first-time folder still works.
+    ``export_ply_to_spz``.  If there is **no** PLY yet but a current ``.spz``
+    sidecar exists (e.g. PLY was removed after a previous export), the file is
+    skipped when ``skip_up_to_date`` is set.  Otherwise this falls back to the
+    full :func:`process_image_to_sidecar_ply` pipeline.
 
     When ``remove_ply_after_spz`` is set, the target ``.ply`` is deleted after a
     successful ``.spz`` write (batch use; keeps disk usage down).

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -374,14 +374,8 @@ def needs_ply_refresh(
     if not ply.is_file():
         # PLY missing — but if SPZ exists and is current vs the image,
         # the work was already done (PLY was removed after SPZ export).
-        if require_spz:
-            spz_path = ply.with_suffix(".spz")
-            if spz_path.is_file():
-                try:
-                    if spz_path.stat().st_mtime >= image_path.stat().st_mtime:
-                        return False
-                except OSError:
-                    pass
+        if require_spz and is_spz_current_for_image(ply, image_path):
+            return False
         return True
     try:
         if image_path.stat().st_mtime > ply.stat().st_mtime:
@@ -407,6 +401,17 @@ def needs_spz_refresh(ply_path: Path) -> bool:
         return spz_path.stat().st_mtime < ply_path.stat().st_mtime
     except OSError:
         return True
+
+
+def is_spz_current_for_image(ply_path: Path, image_path: Path) -> bool:
+    """True when ``ply_path`` has an ``.spz`` sidecar current vs ``image_path``."""
+    spz_path = ply_path.with_suffix(".spz")
+    if not spz_path.is_file():
+        return False
+    try:
+        return spz_path.stat().st_mtime >= image_path.stat().st_mtime
+    except OSError:
+        return False
 
 
 @dataclass
@@ -547,22 +552,16 @@ def _skip_if_spz_current(
     image_path: Path, ply_path: Path
 ) -> Optional[PlySidecarResult]:
     """Return a skipped result if a current .spz exists for a missing PLY, else None."""
-    spz_target = ply_path.with_suffix(".spz")
-    if not spz_target.is_file():
+    if not is_spz_current_for_image(ply_path, image_path):
         return None
-    try:
-        if spz_target.stat().st_mtime >= image_path.stat().st_mtime:
-            return PlySidecarResult(
-                ok=True,
-                image_path=image_path,
-                ply_path=ply_path,
-                message="Skipped (SPZ up to date, PLY previously removed)",
-                skipped=True,
-                spz_path=spz_target,
-            )
-    except OSError:
-        pass
-    return None
+    return PlySidecarResult(
+        ok=True,
+        image_path=image_path,
+        ply_path=ply_path,
+        message="Skipped (SPZ up to date, PLY previously removed)",
+        skipped=True,
+        spz_path=ply_path.with_suffix(".spz"),
+    )
 
 
 def update_ply_sidecar(

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -372,6 +372,16 @@ def needs_ply_refresh(
     """True if the PLY (and optionally the .spz sidecar) needs (re)generating."""
     ply = sidecar_ply_path(image_path) if ply_path is None else ply_path
     if not ply.is_file():
+        # PLY missing — but if SPZ exists and is current vs the image,
+        # the work was already done (PLY was removed after SPZ export).
+        if require_spz:
+            spz_path = ply.with_suffix(".spz")
+            if spz_path.is_file():
+                try:
+                    if spz_path.stat().st_mtime >= image_path.stat().st_mtime:
+                        return False
+                except OSError:
+                    pass
         return True
     try:
         if image_path.stat().st_mtime > ply.stat().st_mtime:
@@ -578,6 +588,22 @@ def update_ply_sidecar(
                 message="SPZ-only mode requires Export SPZ to be enabled",
             )
         if not ply_path.is_file():
+            # PLY missing — check if SPZ already exists and is current
+            # (PLY was likely removed after a previous successful SPZ export).
+            spz_target = ply_path.with_suffix(".spz")
+            if skip_up_to_date and spz_target.is_file():
+                try:
+                    if spz_target.stat().st_mtime >= image_path.stat().st_mtime:
+                        return PlySidecarResult(
+                            ok=True,
+                            image_path=image_path,
+                            ply_path=ply_path,
+                            message="Skipped (SPZ up to date, PLY previously removed)",
+                            skipped=True,
+                            spz_path=spz_target,
+                        )
+                except OSError:
+                    pass
             return process_image_to_sidecar_ply(
                 image_path,
                 limit_splats=limit_splats,
@@ -684,6 +710,24 @@ def update_ply_sidecar(
             decimate_error=decimate_error,
             spz_error=err,
         )
+
+    if skip_up_to_date and not ply_path.is_file() and export_spz:
+        # PLY missing — check if SPZ already exists and is current vs image
+        # (PLY was likely removed after a previous successful SPZ export).
+        spz_target = ply_path.with_suffix(".spz")
+        if spz_target.is_file():
+            try:
+                if spz_target.stat().st_mtime >= image_path.stat().st_mtime:
+                    return PlySidecarResult(
+                        ok=True,
+                        image_path=image_path,
+                        ply_path=ply_path,
+                        message="Skipped (SPZ up to date, PLY previously removed)",
+                        skipped=True,
+                        spz_path=spz_target,
+                    )
+            except OSError:
+                pass
 
     if skip_up_to_date and ply_path.is_file():
         try:

--- a/sharp_local_batch/core.py
+++ b/sharp_local_batch/core.py
@@ -543,6 +543,28 @@ def process_image_to_sidecar_ply(
     )
 
 
+def _skip_if_spz_current(
+    image_path: Path, ply_path: Path
+) -> Optional[PlySidecarResult]:
+    """Return a skipped result if a current .spz exists for a missing PLY, else None."""
+    spz_target = ply_path.with_suffix(".spz")
+    if not spz_target.is_file():
+        return None
+    try:
+        if spz_target.stat().st_mtime >= image_path.stat().st_mtime:
+            return PlySidecarResult(
+                ok=True,
+                image_path=image_path,
+                ply_path=ply_path,
+                message="Skipped (SPZ up to date, PLY previously removed)",
+                skipped=True,
+                spz_path=spz_target,
+            )
+    except OSError:
+        pass
+    return None
+
+
 def update_ply_sidecar(
     image_path: Path,
     *,
@@ -588,22 +610,10 @@ def update_ply_sidecar(
                 message="SPZ-only mode requires Export SPZ to be enabled",
             )
         if not ply_path.is_file():
-            # PLY missing — check if SPZ already exists and is current
-            # (PLY was likely removed after a previous successful SPZ export).
-            spz_target = ply_path.with_suffix(".spz")
-            if skip_up_to_date and spz_target.is_file():
-                try:
-                    if spz_target.stat().st_mtime >= image_path.stat().st_mtime:
-                        return PlySidecarResult(
-                            ok=True,
-                            image_path=image_path,
-                            ply_path=ply_path,
-                            message="Skipped (SPZ up to date, PLY previously removed)",
-                            skipped=True,
-                            spz_path=spz_target,
-                        )
-                except OSError:
-                    pass
+            if skip_up_to_date:
+                skipped = _skip_if_spz_current(image_path, ply_path)
+                if skipped is not None:
+                    return skipped
             return process_image_to_sidecar_ply(
                 image_path,
                 limit_splats=limit_splats,
@@ -712,22 +722,9 @@ def update_ply_sidecar(
         )
 
     if skip_up_to_date and not ply_path.is_file() and export_spz:
-        # PLY missing — check if SPZ already exists and is current vs image
-        # (PLY was likely removed after a previous successful SPZ export).
-        spz_target = ply_path.with_suffix(".spz")
-        if spz_target.is_file():
-            try:
-                if spz_target.stat().st_mtime >= image_path.stat().st_mtime:
-                    return PlySidecarResult(
-                        ok=True,
-                        image_path=image_path,
-                        ply_path=ply_path,
-                        message="Skipped (SPZ up to date, PLY previously removed)",
-                        skipped=True,
-                        spz_path=spz_target,
-                    )
-            except OSError:
-                pass
+        skipped = _skip_if_spz_current(image_path, ply_path)
+        if skipped is not None:
+            return skipped
 
     if skip_up_to_date and ply_path.is_file():
         try:


### PR DESCRIPTION
This pull request improves how the system handles missing PLY files when SPZ sidecar files already exist and are up to date. The changes ensure that unnecessary reprocessing is avoided if the SPZ export has already been completed and the PLY file was subsequently removed. This logic is now consistently applied across batch scanning, refresh checks, and sidecar updates.

**SPZ/PLY Sidecar Handling Improvements:**

* Updated `_spz_only_need`, `_spz_only_need_m`, and `needs_ply_refresh` to check if a missing PLY file can be skipped if the corresponding SPZ file exists and is current, preventing redundant work. [[1]](diffhunk://#diff-d5998adb9f9d06084f210a53448f8af214d8fb249d7caf493c837948e64d1c29R63-R71) [[2]](diffhunk://#diff-d5998adb9f9d06084f210a53448f8af214d8fb249d7caf493c837948e64d1c29R87-R94) [[3]](diffhunk://#diff-b7175232738c0d29fe69a5367ee6da7802afdb28792cde1f99076c24fd5e5a56R375-R384)
* Enhanced `update_ply_sidecar` to skip sidecar generation if the PLY is missing but the SPZ is present and up to date, returning an appropriate result message. This logic is applied both before and after SPZ export attempts. [[1]](diffhunk://#diff-b7175232738c0d29fe69a5367ee6da7802afdb28792cde1f99076c24fd5e5a56R591-R606) [[2]](diffhunk://#diff-b7175232738c0d29fe69a5367ee6da7802afdb28792cde1f99076c24fd5e5a56R714-R731)