### PR TITLE
GH-18: Persist batch GUI settings and reset

### DIFF
--- a/sharp_local_batch/gui.py
+++ b/sharp_local_batch/gui.py
@@ -7,11 +7,17 @@ import sys
 import threading
 import time
 import tkinter as tk
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from tkinter import filedialog, messagebox, ttk
 
 from sharp_local_batch.batch_runner import WatchController, scan_jobs
+from sharp_local_batch.gui_settings import (
+    clear_saved_batch_gui_settings,
+    default_batch_gui_settings,
+    load_batch_gui_settings,
+    save_batch_gui_settings,
+)
 from sharp_local_batch.core import (
     PHOTOS_LIBRARY_MIRROR_HELP,
     PlySidecarResult,
@@ -68,6 +74,73 @@ class SharpBatchGui:
         self._worker.start()
 
         self.root.protocol("WM_DELETE_WINDOW", self._on_close)
+
+        self._apply_persisted_settings(load_batch_gui_settings())
+
+    def _collect_persisted_settings(self) -> dict[str, object]:
+        return {
+            "folder": self._folder_var.get().strip(),
+            "recursive": self._recursive_var.get(),
+            "force_all": self._force_all_var.get(),
+            "limit_splats": self._limit_var.get(),
+            "max_splats": self._max_splats_var.get().strip() or "500000",
+            "skip_up_to_date": self._skip_up_to_date_var.get(),
+            "export_spz": self._spz_var.get(),
+            "spz_only": self._spz_only_var.get(),
+            "remove_ply_after_spz": self._remove_ply_after_spz_var.get(),
+            "mirror": self._mirror_var.get(),
+            "output_mirror": self._output_mirror_var.get().strip(),
+            "use_photos_library": self._photos_lib_var.get(),
+        }
+
+    def _apply_persisted_settings(self, d: Mapping[str, object]) -> None:
+        self._recursive_var.set(bool(d.get("recursive", True)))
+        self._force_all_var.set(bool(d.get("force_all", False)))
+        self._limit_var.set(bool(d.get("limit_splats", False)))
+        self._max_splats_var.set(str(d.get("max_splats", "500000")))
+        self._skip_up_to_date_var.set(bool(d.get("skip_up_to_date", True)))
+        self._spz_var.set(bool(d.get("export_spz", True)))
+        self._spz_only_var.set(bool(d.get("spz_only", False)))
+        self._remove_ply_after_spz_var.set(bool(d.get("remove_ply_after_spz", True)))
+        self._output_mirror_var.set(str(d.get("output_mirror", "")))
+
+        use_pl = bool(d.get("use_photos_library", False)) and sys.platform == "darwin"
+        lib = default_macos_photos_library_path()
+        lib_ok = use_pl and lib.is_dir()
+
+        if lib_ok:
+            self._photos_lib_var.set(True)
+            self._folder_var.set(str(lib))
+            self._mirror_var.set(True)
+            self._mirror_cb.state(["disabled"])
+        else:
+            self._photos_lib_var.set(False)
+            self._mirror_cb.state(["!disabled"])
+            self._folder_var.set(str(d.get("folder", "")))
+            self._mirror_var.set(bool(d.get("mirror", False)))
+
+        self._sync_force_skip_widgets()
+        self._sync_limit_widgets()
+        self._on_spz_only_toggle()
+        self._sync_remove_ply_widgets()
+        self._sync_mirror_widgets()
+
+    def _persist_gui_settings(self) -> None:
+        try:
+            save_batch_gui_settings(self._collect_persisted_settings())
+        except OSError:
+            pass
+
+    def _on_reset_settings(self) -> None:
+        if not messagebox.askyesno(
+            "Reset settings",
+            "Restore all options to defaults and forget saved preferences?",
+            default=messagebox.NO,
+        ):
+            return
+        clear_saved_batch_gui_settings()
+        self._apply_persisted_settings(default_batch_gui_settings())
+        self._log_line("--- Settings reset to defaults (saved preferences cleared) ---")
 
     def _build_ui(self) -> None:
         pad = {"padx": 10, "pady": 4}
@@ -198,6 +271,9 @@ class SharpBatchGui:
             side=tk.LEFT
         )
         ttk.Button(row4, text="Stop", command=self._on_stop).pack(side=tk.LEFT, padx=(8, 0))
+        ttk.Button(row4, text="Reset settings", command=self._on_reset_settings).pack(
+            side=tk.LEFT, padx=(8, 0)
+        )
         self._watch_cb = ttk.Checkbutton(
             row4,
             text="Watch folder (new / changed images)",
@@ -650,6 +726,7 @@ class SharpBatchGui:
             pass
 
     def _on_close(self) -> None:
+        self._persist_gui_settings()
         self._stop_watch()
         self._quit_app.set()
         self.root.destroy()

--- a/sharp_local_batch/gui.py
+++ b/sharp_local_batch/gui.py
@@ -125,6 +125,7 @@ class SharpBatchGui:
         self._sync_remove_ply_widgets()
         self._sync_mirror_widgets()
 
+    # save_batch_gui_settings removes gui_settings.json when merged values match defaults.
     def _persist_gui_settings(self) -> None:
         try:
             save_batch_gui_settings(self._collect_persisted_settings())

--- a/sharp_local_batch/gui_qt.py
+++ b/sharp_local_batch/gui_qt.py
@@ -7,6 +7,7 @@ import sys
 import threading
 import time
 from pathlib import Path
+from typing import Mapping
 
 from PySide6.QtCore import QObject, Qt, Signal, Slot
 from PySide6.QtGui import QCloseEvent
@@ -30,6 +31,12 @@ from PySide6.QtWidgets import (
 )
 
 from sharp_local_batch.batch_runner import WatchController, scan_jobs
+from sharp_local_batch.gui_settings import (
+    clear_saved_batch_gui_settings,
+    default_batch_gui_settings,
+    load_batch_gui_settings,
+    save_batch_gui_settings,
+)
 from sharp_local_batch.core import (
     PHOTOS_LIBRARY_MIRROR_HELP,
     PlySidecarResult,
@@ -188,6 +195,10 @@ class SharpBatchQtWindow(QMainWindow):
         stop_btn = QPushButton("Stop")
         stop_btn.clicked.connect(self._on_stop)
         row4.addWidget(stop_btn)
+        reset_btn = QPushButton("Reset settings")
+        reset_btn.setToolTip("Restore defaults and clear saved preferences for next launch.")
+        reset_btn.clicked.connect(self._on_reset_settings)
+        row4.addWidget(reset_btn)
         self._watch_chk = QCheckBox("Watch folder (new / changed images)")
         self._watch_chk.toggled.connect(self._on_watch_toggled)
         row4.addWidget(self._watch_chk)
@@ -233,6 +244,81 @@ class SharpBatchQtWindow(QMainWindow):
         layout.addWidget(foot)
 
         threading.Thread(target=self._worker_loop, daemon=True).start()
+
+        self._apply_persisted_settings(load_batch_gui_settings())
+
+    def _collect_persisted_settings(self) -> dict[str, object]:
+        use_pl = (
+            bool(self._photos_lib_chk.isChecked())
+            if self._photos_lib_chk is not None
+            else False
+        )
+        return {
+            "folder": self._folder_edit.text().strip(),
+            "recursive": self._recursive_chk.isChecked(),
+            "force_all": self._force_all_chk.isChecked(),
+            "limit_splats": self._limit_chk.isChecked(),
+            "max_splats": self._max_edit.text().strip() or "500000",
+            "skip_up_to_date": self._skip_chk.isChecked(),
+            "export_spz": self._spz_chk.isChecked(),
+            "spz_only": self._spz_only_chk.isChecked(),
+            "remove_ply_after_spz": self._remove_ply_chk.isChecked(),
+            "mirror": self._mirror_chk.isChecked(),
+            "output_mirror": self._output_mirror_edit.text().strip(),
+            "use_photos_library": use_pl,
+        }
+
+    def _apply_persisted_settings(self, d: Mapping[str, object]) -> None:
+        self._recursive_chk.setChecked(bool(d.get("recursive", True)))
+        self._force_all_chk.setChecked(bool(d.get("force_all", False)))
+        self._limit_chk.setChecked(bool(d.get("limit_splats", False)))
+        self._max_edit.setText(str(d.get("max_splats", "500000")))
+        self._skip_chk.setChecked(bool(d.get("skip_up_to_date", True)))
+        self._spz_chk.setChecked(bool(d.get("export_spz", True)))
+        self._spz_only_chk.setChecked(bool(d.get("spz_only", False)))
+        self._remove_ply_chk.setChecked(bool(d.get("remove_ply_after_spz", True)))
+        self._output_mirror_edit.setText(str(d.get("output_mirror", "")))
+
+        use_pl = bool(d.get("use_photos_library", False)) and sys.platform == "darwin"
+        lib_ok = False
+        if use_pl and self._photos_lib_chk is not None:
+            lib = default_macos_photos_library_path()
+            lib_ok = lib.is_dir()
+
+        if use_pl and lib_ok and self._photos_lib_chk is not None:
+            self._photos_lib_chk.setChecked(True)
+        else:
+            if self._photos_lib_chk is not None:
+                self._photos_lib_chk.setChecked(False)
+            self._folder_edit.setText(str(d.get("folder", "")))
+            self._mirror_chk.setChecked(bool(d.get("mirror", False)))
+
+        self._sync_force_skip_widgets(False)
+        self._sync_limit_widgets()
+        self._on_spz_only_toggled(self._spz_only_chk.isChecked())
+        self._sync_remove_ply_widgets()
+        self._sync_mirror_widgets(self._mirror_chk.isChecked())
+
+    def _persist_gui_settings(self) -> None:
+        try:
+            save_batch_gui_settings(self._collect_persisted_settings())
+        except OSError:
+            pass
+
+    @Slot()
+    def _on_reset_settings(self) -> None:
+        reply = QMessageBox.question(
+            self,
+            "Reset settings",
+            "Restore all options to defaults and forget saved preferences?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if reply != QMessageBox.StandardButton.Yes:
+            return
+        clear_saved_batch_gui_settings()
+        self._apply_persisted_settings(default_batch_gui_settings())
+        self._log_line("--- Settings reset to defaults (saved preferences cleared) ---")
 
     def _sync_limit_widgets(self) -> None:
         self._max_edit.setEnabled(self._limit_chk.isChecked())
@@ -666,6 +752,7 @@ class SharpBatchQtWindow(QMainWindow):
         self._log.append(text)
 
     def closeEvent(self, event: QCloseEvent) -> None:
+        self._persist_gui_settings()
         self._stop_watch()
         self._quit_app.set()
         event.accept()

--- a/sharp_local_batch/gui_qt.py
+++ b/sharp_local_batch/gui_qt.py
@@ -299,6 +299,7 @@ class SharpBatchQtWindow(QMainWindow):
         self._sync_remove_ply_widgets()
         self._sync_mirror_widgets(self._mirror_chk.isChecked())
 
+    # save_batch_gui_settings removes gui_settings.json when merged values match defaults.
     def _persist_gui_settings(self) -> None:
         try:
             save_batch_gui_settings(self._collect_persisted_settings())

--- a/sharp_local_batch/gui_settings.py
+++ b/sharp_local_batch/gui_settings.py
@@ -1,0 +1,100 @@
+"""Load/save batch GUI form state (Qt and Tk) under the user home directory."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+_SCHEMA_VERSION = 1
+
+
+def settings_file_path() -> Path:
+    return Path.home() / ".sharp_local_batch" / "gui_settings.json"
+
+
+def default_batch_gui_settings() -> dict[str, Any]:
+    return {
+        "schema_version": _SCHEMA_VERSION,
+        "folder": "",
+        "recursive": True,
+        "force_all": False,
+        "limit_splats": False,
+        "max_splats": "500000",
+        "skip_up_to_date": True,
+        "export_spz": True,
+        "spz_only": False,
+        "remove_ply_after_spz": True,
+        "mirror": False,
+        "output_mirror": "",
+        "use_photos_library": False,
+    }
+
+
+def _as_bool(value: object, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and value in (0, 1):
+        return bool(value)
+    return default
+
+
+def _as_str(value: object, default: str) -> str:
+    if isinstance(value, str):
+        return value
+    return default
+
+
+def load_batch_gui_settings() -> dict[str, Any]:
+    base = default_batch_gui_settings()
+    path = settings_file_path()
+    if not path.is_file():
+        return base
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return base
+    if not isinstance(raw, dict):
+        return base
+    bool_keys = (
+        "recursive",
+        "force_all",
+        "limit_splats",
+        "skip_up_to_date",
+        "export_spz",
+        "spz_only",
+        "remove_ply_after_spz",
+        "mirror",
+        "use_photos_library",
+    )
+    for key in bool_keys:
+        if key in raw:
+            base[key] = _as_bool(raw[key], base[key])
+    for key in ("folder", "max_splats", "output_mirror"):
+        if key in raw:
+            base[key] = _as_str(raw[key], base[key])
+    base["schema_version"] = _SCHEMA_VERSION
+    return base
+
+
+def save_batch_gui_settings(data: Mapping[str, Any]) -> None:
+    defaults = default_batch_gui_settings()
+    merged: dict[str, Any] = {**defaults}
+    for key in defaults:
+        if key == "schema_version":
+            continue
+        if key in data:
+            merged[key] = data[key]
+    merged["schema_version"] = _SCHEMA_VERSION
+    path = settings_file_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(merged, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def clear_saved_batch_gui_settings() -> None:
+    path = settings_file_path()
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass

--- a/sharp_local_batch/gui_settings.py
+++ b/sharp_local_batch/gui_settings.py
@@ -32,6 +32,19 @@ def default_batch_gui_settings() -> dict[str, Any]:
     }
 
 
+_BOOL_KEYS = (
+    "recursive",
+    "force_all",
+    "limit_splats",
+    "skip_up_to_date",
+    "export_spz",
+    "spz_only",
+    "remove_ply_after_spz",
+    "mirror",
+    "use_photos_library",
+)
+
+
 def _as_bool(value: object, default: bool) -> bool:
     if isinstance(value, bool):
         return value
@@ -57,18 +70,7 @@ def load_batch_gui_settings() -> dict[str, Any]:
         return base
     if not isinstance(raw, dict):
         return base
-    bool_keys = (
-        "recursive",
-        "force_all",
-        "limit_splats",
-        "skip_up_to_date",
-        "export_spz",
-        "spz_only",
-        "remove_ply_after_spz",
-        "mirror",
-        "use_photos_library",
-    )
-    for key in bool_keys:
+    for key in _BOOL_KEYS:
         if key in raw:
             base[key] = _as_bool(raw[key], base[key])
     for key in ("folder", "max_splats", "output_mirror"):
@@ -78,7 +80,7 @@ def load_batch_gui_settings() -> dict[str, Any]:
     return base
 
 
-def save_batch_gui_settings(data: Mapping[str, Any]) -> None:
+def _merge_batch_gui_settings(data: Mapping[str, Any]) -> dict[str, Any]:
     defaults = default_batch_gui_settings()
     merged: dict[str, Any] = {**defaults}
     for key in defaults:
@@ -87,7 +89,38 @@ def save_batch_gui_settings(data: Mapping[str, Any]) -> None:
         if key in data:
             merged[key] = data[key]
     merged["schema_version"] = _SCHEMA_VERSION
+    return merged
+
+
+def _merged_equals_defaults(merged: Mapping[str, Any]) -> bool:
+    """True if merged settings match defaults (same normalization as load)."""
+    d = default_batch_gui_settings()
+    for key in _BOOL_KEYS:
+        if _as_bool(merged.get(key), d[key]) != d[key]:
+            return False
+    folder = _as_str(merged.get("folder"), "").strip()
+    if folder != d["folder"]:
+        return False
+    max_splats = _as_str(merged.get("max_splats"), d["max_splats"]).strip()
+    if not max_splats:
+        max_splats = d["max_splats"]
+    if max_splats != d["max_splats"]:
+        return False
+    output_mirror = _as_str(merged.get("output_mirror"), "").strip()
+    if output_mirror != d["output_mirror"]:
+        return False
+    return True
+
+
+def save_batch_gui_settings(data: Mapping[str, Any]) -> None:
+    merged = _merge_batch_gui_settings(data)
     path = settings_file_path()
+    if _merged_equals_defaults(merged):
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(merged, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 


### PR DESCRIPTION
Restore folder path, mirror targets, and processing options from ~/.sharp_local_batch/gui_settings.json on launch; save on quit. Add Reset settings to restore defaults and remove the saved file.