### PR TITLE
Feature/#21 automatically create release archives

### DIFF
--- a/compile-binaries-mac.sh
+++ b/compile-binaries-mac.sh
@@ -27,9 +27,17 @@ echo "Building SharpBatch..."
 echo "Building SharpWeb..."
 "$ROOT/$PYTHON" -m PyInstaller packaging/sharp_web.spec
 
+VERSION=$("$ROOT/$PYTHON" -c "from sharp_local_batch._version import __version__; print(__version__)")
+
+echo "Packaging archives..."
+cd "$ROOT/dist"
+zip -r "SharpBatch-${VERSION}-mac.zip" SharpBatch/
+zip -r "SharpWeb-${VERSION}-mac.zip" SharpWeb/
+cd "$ROOT"
+
 echo ""
 echo "========================================================================"
-echo "Build finished OK."
+echo "Build finished OK — version ${VERSION}."
 echo ""
 echo "Batch tool (GUI/CLI):"
 echo "  $ROOT/dist/SharpBatch/SharpBatch"
@@ -39,7 +47,9 @@ echo "Web UI (Flask server — open http://127.0.0.1:8765 after starting):"
 echo "  $ROOT/dist/SharpWeb/SharpWeb"
 echo "  Folder: $ROOT/dist/SharpWeb/"
 echo ""
-echo "Ship each app by zipping the whole folder above (include _internal/)."
+echo "Archives (upload these to the GitHub release):"
+echo "  $ROOT/dist/SharpBatch-${VERSION}-mac.zip"
+echo "  $ROOT/dist/SharpWeb-${VERSION}-mac.zip"
 echo ""
 echo "NOTE: bundles built locally are not notarised. To open them the first"
 echo "  time: right-click → Open → Open, or run:"

--- a/compile-binaries-win.bat
+++ b/compile-binaries-win.bat
@@ -20,12 +20,13 @@ echo Building SharpWeb...
 ".venv\Scripts\python.exe" -m PyInstaller packaging\sharp_web.spec
 if errorlevel 1 exit /b 1
 
-for /f "delims=" %%V in ('".venv\Scripts\python.exe" -c "from sharp_local_batch._version import __version__; print(__version__)"') do set VERSION=%%V
+".venv\Scripts\python.exe" -c "from sharp_local_batch._version import __version__; print(__version__)" > _ver_tmp.txt
+set /p VERSION=<_ver_tmp.txt
+del _ver_tmp.txt
 
 echo Packaging archives...
 cd dist
-powershell -NoProfile -Command "Compress-Archive -Force -Path SharpBatch -DestinationPath 'SharpBatch-%VERSION%-win.zip'"
-powershell -NoProfile -Command "Compress-Archive -Force -Path SharpWeb -DestinationPath 'SharpWeb-%VERSION%-win.zip'"
+powershell -NoProfile -Command "Compress-Archive -Force -Path SharpBatch -DestinationPath 'SharpBatch-%VERSION%-win.zip'; Compress-Archive -Force -Path SharpWeb -DestinationPath 'SharpWeb-%VERSION%-win.zip'"
 cd ..
 
 echo.

--- a/compile-binaries-win.bat
+++ b/compile-binaries-win.bat
@@ -20,9 +20,17 @@ echo Building SharpWeb...
 ".venv\Scripts\python.exe" -m PyInstaller packaging\sharp_web.spec
 if errorlevel 1 exit /b 1
 
+for /f "delims=" %%V in ('".venv\Scripts\python.exe" -c "from sharp_local_batch._version import __version__; print(__version__)"') do set VERSION=%%V
+
+echo Packaging archives...
+cd dist
+powershell -NoProfile -Command "Compress-Archive -Force -Path SharpBatch -DestinationPath 'SharpBatch-%VERSION%-win.zip'"
+powershell -NoProfile -Command "Compress-Archive -Force -Path SharpWeb -DestinationPath 'SharpWeb-%VERSION%-win.zip'"
+cd ..
+
 echo.
 echo ========================================================================
-echo Build finished OK.
+echo Build finished OK -- version %VERSION%.
 echo.
 echo Batch tool (GUI/CLI^):
 echo   %cd%\dist\SharpBatch\SharpBatch.exe
@@ -32,7 +40,9 @@ echo Web UI (Flask server — open http://127.0.0.1:8765 after starting^):
 echo   %cd%\dist\SharpWeb\SharpWeb.exe
 echo   Folder: %cd%\dist\SharpWeb\
 echo.
-echo Ship each app by zipping the whole folder above (include _internal^).
+echo Archives (upload these to the GitHub release^):
+echo   %cd%\dist\SharpBatch-%VERSION%-win.zip
+echo   %cd%\dist\SharpWeb-%VERSION%-win.zip
 echo ========================================================================
 if /i "%~1"=="nopause" (
   endlocal


### PR DESCRIPTION
This pull request updates the build scripts for both macOS and Windows to automatically package versioned zip archives of the built applications and improve the release instructions. The changes streamline the release process by including version numbers in the archive filenames and clarifying which files to upload for releases.

**Build and packaging automation:**

* The macOS build script (`compile-binaries-mac.sh`) now automatically creates versioned zip archives for both `SharpBatch` and `SharpWeb` after building, using the version from the Python package.
* The Windows build script (`compile-binaries-win.bat`) now similarly creates versioned zip archives for both apps by extracting the version from the Python package and using PowerShell's `Compress-Archive`.

**Release instructions and output improvements:**

* Both scripts update their output to display the paths to the new versioned archives and instruct users to upload these files to the GitHub release, replacing previous manual instructions. [[1]](diffhunk://#diff-712a4e16196a25e956b06131dd10f7299058dc5d7671e0385ac3ac49123add87L42-R52) [[2]](diffhunk://#diff-8b0740d6bb73142955294a2d55ff0e27f4cced2deab803a07c321f2d3c67b968L35-R46)
* The build completion messages now include the version number to make it clear which version was built. [[1]](diffhunk://#diff-712a4e16196a25e956b06131dd10f7299058dc5d7671e0385ac3ac49123add87R30-R40) [[2]](diffhunk://#diff-8b0740d6bb73142955294a2d55ff0e27f4cced2deab803a07c321f2d3c67b968R23-R34)